### PR TITLE
fix: generating changelog

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,8 +76,9 @@
         "@semantic-release/git",
         {
           "assets": [
-            "gcspath.py",
-            "package.json"
+            "gcspath/about.py",
+            "package.json",
+            "CHANGELOG.md"
           ],
           "message": "chore(release): ${nextRelease.version} \n\n${nextRelease.notes}"
         }


### PR DESCRIPTION
The file paths for generating git commits were wrong. Fix them so semantic-release git plugin will commit the changelog and updated package version.