### PR TITLE
fix(gcs): gracefully handle invalid gcs client case

### DIFF
--- a/gcspath/__init__.py
+++ b/gcspath/__init__.py
@@ -1,12 +1,14 @@
-from .api import GCSPath, PureGCSPath  # noqa
-from .client import BucketEntry, BucketStat  # noqa
 from .api import (  # noqa
-    get_fs_client,
-    use_fs,
     BucketClient,
+    BucketsAccessor,
     ClientBlob,
     ClientBucket,
     ClientError,
+    GCSPath,
+    PureGCSPath,
+    get_fs_client,
+    use_fs,
 )
+from .client import BucketEntry, BucketStat  # noqa
 from .file import BucketClientFS, BucketEntryFS, ClientBlobFS, ClientBucketFS  # noqa
 from .gcs import BucketClientGCS, BucketEntryGCS, ClientBlobGCS, ClientBucketGCS  # noqa

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,9 +6,14 @@ from gcspath import use_fs
 
 
 @pytest.fixture()
-def with_fs():
+def temp_folder():
     tmp_dir = tempfile.mkdtemp()
     yield Path(tmp_dir)
     shutil.rmtree(tmp_dir)
+
+
+@pytest.fixture()
+def with_fs(temp_folder):
+    yield temp_folder
     # Turn off FS adapter
     use_fs(False)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,5 +1,10 @@
 from pathlib import Path
-from gcspath import get_fs_client, use_fs, BucketClientFS
+
+import mock
+import pytest
+from google.auth.exceptions import DefaultCredentialsError
+
+from gcspath import BucketClientFS, BucketsAccessor, get_fs_client, use_fs
 
 
 def test_use_fs(with_fs: Path):
@@ -22,3 +27,15 @@ def test_use_fs(with_fs: Path):
     assert client.root == with_fs
 
     use_fs(False)
+
+
+@mock.patch("gcspath.gcs.BucketClientGCS", side_effect=DefaultCredentialsError())
+def test_bucket_accessor_without_gcs(bucket_client_gcs_mock, temp_folder):
+    accessor = BucketsAccessor()
+    # Accessing the client lazily throws with no GCS or FS adapters configured
+    with pytest.raises(AssertionError):
+        accessor.client
+
+    # Setting a fallback FS adapter fixes the problem
+    use_fs(str(temp_folder))
+    assert isinstance(accessor.client, BucketClientFS)


### PR DESCRIPTION
 - by default ignore default client credential errors until the accessor.client prop is referenced.
 - this allows you to call `use_fs` after the initial module import