### PR TITLE
feat(use_fs): allow passing root folder as Path

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -26,6 +26,13 @@ def test_use_fs(with_fs: Path):
     assert isinstance(client, BucketClientFS)
     assert client.root == with_fs
 
+    # Can use a pathlib.Path
+    use_fs(with_fs)
+    client = get_fs_client()
+    assert isinstance(client, BucketClientFS)
+    assert client.root == with_fs
+
+
     use_fs(False)
 
 


### PR DESCRIPTION
 - in practice the error that is raised when passing a path is annoying and not helpful since the following line converts it to a path anyway.