### PR TITLE
feat: allow passing GCSPath to spacy.Model.to_disk

### DIFF
--- a/gcspath/file.py
+++ b/gcspath/file.py
@@ -108,9 +108,8 @@ class BucketClientFS(BucketClient):
 
         full_path = self.full_path(path)
         if not full_path.exists():
-            if full_path.suffix != "":
-                str_full = str(full_path)
-                full_path = pathlib.Path(str_full[: str_full.rindex("/") + 1])
+            if full_path.name != "":
+                full_path = full_path.parent
             full_path.mkdir(parents=True, exist_ok=True)
         return super().open(
             path,
@@ -231,11 +230,8 @@ class BucketClientFS(BucketClient):
                 raw=scan_path,
             )
 
-        # If the path can't be scanned, yield nothing and return
-        dir_entries_generator = scan_path.rglob("*")
-
-        # Yield blobs for each file (non-folder)
-        for file_path in dir_entries_generator:
+        # Yield blobs for each file
+        for file_path in scan_path.rglob("*"):
             if file_path.is_dir():
                 continue
             stat = file_path.stat()

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,3 +5,7 @@ black
 pytest-coverage
 tox
 mock
+
+# test serializing spacy models using GCSPath in place of Path
+https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-2.2.5/en_core_web_sm-2.2.5.tar.gz#egg=en_core_web_sm
+spacy

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1,0 +1,22 @@
+from pathlib import Path
+
+import pytest
+
+import spacy
+from gcspath import GCSPath, use_fs
+
+
+def test_export_spacy_model(temp_folder):
+    use_fs(temp_folder)
+    bucket = GCSPath("/my-bucket/")
+    bucket.mkdir(exist_ok=True)
+    model = spacy.blank("en")
+    output_path = GCSPath("/my-bucket/models/my_model")
+    model.to_disk(output_path)
+    sorted_entries = sorted([str(p) for p in output_path.glob("*")])
+    expected_entries = [
+        "/my-bucket/models/my_model/meta.json",
+        "/my-bucket/models/my_model/tokenizer",
+        "/my-bucket/models/my_model/vocab",
+    ]
+    assert sorted_entries == expected_entries


### PR DESCRIPTION
 - add test that exports a blank model then enumerates its files from the GCSPath