### PR TITLE
fix(iterdir): don't return empty results

### DIFF
--- a/gcspath/gcs.py
+++ b/gcspath/gcs.py
@@ -131,15 +131,18 @@ class BucketClientGCS(BucketClient):
                 for folder in list(page.prefixes):
                     full_name = folder[:-1] if folder.endswith(sep) else folder
                     name = full_name.split(sep)[-1]
-                    yield BucketEntryGCS(name, is_dir=True, raw=None)
+                    if name:
+                        yield BucketEntryGCS(name, is_dir=True, raw=None)
                 for item in page:
-                    yield BucketEntryGCS(
-                        name=item.name.split(sep)[-1],
-                        is_dir=False,
-                        size=item.size,
-                        last_modified=item.updated.timestamp(),
-                        raw=item,
-                    )
+                    name = item.name.split(sep)[-1]
+                    if name:
+                        yield BucketEntryGCS(
+                            name=name,
+                            is_dir=False,
+                            size=item.size,
+                            last_modified=item.updated.timestamp(),
+                            raw=item,
+                        )
             if response.next_page_token is None:
                 break
             continuation_token = response.next_page_token

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -282,6 +282,15 @@ def test_iterdir(with_adapter):
 
 
 @pytest.mark.parametrize("adapter", TEST_ADAPTERS)
+def test_iterdir_pipstore(with_adapter):
+    path = GCSPath.from_bucket(bucket) / "iterdir/pipstore/prodigy/prodigy.whl"
+    path.write_bytes(b"---")
+    path = GCSPath.from_bucket(bucket) / "iterdir/pipstore"
+    res = [e.name for e in sorted(path.iterdir())]
+    assert res == ["prodigy"]
+
+
+@pytest.mark.parametrize("adapter", TEST_ADAPTERS)
 def test_open_for_read(with_adapter):
     path = GCSPath(f"/{bucket}/read/file.txt")
     path.write_text("---")


### PR DESCRIPTION
- when iterating a pipstore folder, the source folder was returned with an empty name