### PR TITLE
feat(typing): expose library python types to mypy

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2019 Lior Mizrahi
+   Copyright 2020 Justin DuJardin
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
-include gcspath.py
 include setup.py
 include README.md
 include LICENSE
+include gcspath/py.typed

--- a/gcspath/api.py
+++ b/gcspath/api.py
@@ -118,6 +118,12 @@ class GCSPath(Path, PureGCSPath):
     __slots__ = ()
     _NOT_SUPPORTED_MESSAGE = "{method} is an unsupported bucket operation"
 
+    def __truediv__(self, key) -> "GCSPath":
+        return super().__truediv__(key)
+
+    def __rtruediv__(self, key) -> "GCSPath":
+        return super().__rtruediv__(key)
+
     def _init(self, template=None):
         super()._init(template)
         if template is None:

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ def setup_package():
         license=about["__license__"],
         long_description=long_description,
         long_description_content_type="text/markdown",
+        include_package_data=True,
         packages=find_packages(),
         python_requires=">= 3.6",
         install_requires=requirements,


### PR DESCRIPTION
 - add py.typed file and include in the package
 - overload / operator to provide a definitive GCSPath return type when building paths