### PR TITLE
fix: upgrade smart-open range to >=2.2.0,<4.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-smart-open>=2.2.0,<3.0.0
+smart-open>=2.2.0,<4.0.0
 typer>=0.3.0,<1.0.0
 dataclasses>=0.6,<1.0; python_version < "3.7"


### PR DESCRIPTION
⬆️ Upgrade `smart-open` pin, to fix `botocore` requiring `urllib3` < 1.26

When standard `pip` installs the latest `pathy`, it installs `smart-open` < 3.0.0, and it requires `botocore`, which in turn requires `urllib3` < 1.26. But it seems something else also requires `urllib3`, and that one is resolved first, so `pip` (the current version) installs the newer `urllib3` and shows a warning about the conflicting dependency.

But when using Pex, it doesn't show a warning, it fails right away.

The funny thing is, `pip`, with the new resolver (with `--use-feature=2020-resolver`) can detect it, then it uninstalls the first resolved `urllib3` and installs the older `urllib3` 1.25.x. But there's no way to force Pex to use that new resolver :pensive: 

The [new version of `smart-open` 3.0.0](https://github.com/RaRe-Technologies/smart_open/releases/tag/3.0.0) doesn't require `botocore`, instead it has new optional requirements:

```
pip install smart_open[s3]
```

or

```
pip install smart_open[all]
```

---

This PR only increases the pin range for `smart-open`.

There would also be needed a Pathy version bump and release :grimacing: :sweat_smile: 

And I don't know if it would make sense to make it require `smart-open[gcp]` directly, but that would couple Pathy to Google Cloud Storage. Or maybe it could make sense to add optional dependencies for Pathy similar to `smart-open`, so `pathy[gcp]` would include `smart-open[gcp]`.