### PR TITLE
fix: path.scheme would error with scheme-less paths

### DIFF
--- a/pathy/base.py
+++ b/pathy/base.py
@@ -235,8 +235,12 @@ class PurePathy(PurePath):
         ```python
         assert Pathy("gs://foo/bar").scheme == "gs"
         assert Pathy("file:///tmp/foo/bar").scheme == "file"
+        assert Pathy("/dev/null").scheme == ""
 
         """
+        # If there is no drive, return nothing
+        if self.drive == "":
+            return ""
         # This is an assumption of mine. I think it's fine, but let's
         # cause an error if it's not the case.
         assert self.drive[-1] == ":", "drive should end with :"

--- a/pathy/clients.py
+++ b/pathy/clients.py
@@ -11,6 +11,7 @@ from .gcs import BucketClientGCS
 #       hardcode it (atleast the base schemes) to get nice types flowing
 #       in cases where they would otherwise be lost.
 _client_registry: Dict[str, Type[BucketClient]] = {
+    "": BucketClientFS,
     "file": BucketClientFS,
     "gs": BucketClientGCS,
 }

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -129,6 +129,13 @@ def test_base_repr():
     assert bytes(PurePathy("fake_file.txt")) == b"fake_file.txt"
 
 
+def test_base_scheme_extraction():
+    assert PurePathy("gs://var/tests/fake").scheme == "gs"
+    assert PurePathy("s3://var/tests/fake").scheme == "s3"
+    assert PurePathy("file://var/tests/fake").scheme == "file"
+    assert PurePathy("/var/tests/fake").scheme == ""
+
+
 @pytest.mark.skipif(sys.version_info < (3, 6), reason="requires python3.6 or higher")
 def test_base_fspath():
     assert os.fspath(PurePathy("/var/tests/fake")) == "/var/tests/fake"

--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -14,6 +14,7 @@ from .conftest import TEST_ADAPTERS
 def test_clients_get_client_works_with_builtin_schems():
     assert isinstance(get_client("gs"), BucketClientGCS)
     assert isinstance(get_client("file"), BucketClientFS)
+    assert isinstance(get_client(""), BucketClientFS)
 
 
 def test_clients_get_client_errors_with_unknown_scheme():


### PR DESCRIPTION
- return "" from file paths like "/dev/null" rather than error
- update `get_client` to return file client for scheme-less paths