### PR TITLE
feat(clients): add set_client_params for specifying client-specific args

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,6 +367,16 @@ get_fs_cache() -> Optional[pathlib.Path]
 
 Get the folder that holds file-system cached blobs and timestamps.
 
+# set_client_params <kbd>function</kbd>
+
+```python
+set_client_params(scheme: str, kwargs: Any) -> None
+```
+
+Specify args to pass when instantiating a service-specific Client
+object. This allows for passing credentials in whatever way your underlying
+client library prefers.
+
 # CLI
 
 Pathy command line interface.

--- a/README.md
+++ b/README.md
@@ -18,11 +18,14 @@ pip install pathy
 The package exports the `Pathy` class and utilities for configuring the bucket storage provider to use. By default Pathy prefers GoogleCloudStorage paths of the form `gs://bucket_name/folder/blob_name.txt`. Internally Pathy can convert GCS paths to local files, allowing for a nice developer experience.
 
 ```python
-from pathy import Pathy
-
-# Any bucket you have access to will work
+from pathy import Pathy, use_fs
+# Use the local file-system for quicker development
+use_fs()
+# Create a bucket
+Pathy("gs://my_bucket").mkdir(exist_ok=True)
+# An excellent blob
 greeting = Pathy(f"gs://my_bucket/greeting.txt")
-# The blob doesn't exist yet
+# But it doesn't exist yet
 assert not greeting.exists()
 # Create it by writing some text
 greeting.write_text("Hello World!")
@@ -94,11 +97,13 @@ If you need to use specific implementation details of a type, "narrow" the
 return of this function to the desired type, e.g.
 
 ```python
-fluid_path = FluidPath("gs://my_bucket/foo.txt")
+from pathy import FluidPath, Pathy
+
+fluid_path: FluidPath = Pathy.fluid("gs://my_bucket/foo.txt")
 # Narrow the type to a specific class
 assert isinstance(fluid_path, Pathy), "must be Pathy"
 # Use a member specific to that class
-print(fluid_path.prefix)
+assert fluid_path.prefix == "foo.txt/"
 ```
 
 ## from_bucket <kbd>classmethod</kbd>
@@ -111,6 +116,8 @@ Initialize a Pathy from a bucket name. This helper adds a trailing slash and
 the appropriate prefix.
 
 ```python
+from pathy import Pathy
+
 assert str(Pathy.from_bucket("one")) == "gs://one/"
 assert str(Pathy.from_bucket("two")) == "gs://two/"
 ```
@@ -244,6 +251,8 @@ Pathy.resolve(self, strict: bool = False) -> 'Pathy'
 Resolve the given path to remove any relative path specifiers.
 
 ```python
+from pathy import Pathy
+
 path = Pathy("gs://my_bucket/folder/../blob")
 assert path.resolve() == Pathy("gs://my_bucket/blob")
 ```

--- a/pathy/__init__.py
+++ b/pathy/__init__.py
@@ -16,6 +16,7 @@ from .clients import (
     get_fs_cache,
     get_fs_client,
     register_client,
+    set_client_params,
     use_fs,
     use_fs_cache,
 )

--- a/pathy/base.py
+++ b/pathy/base.py
@@ -130,6 +130,10 @@ class Bucket:
 class BucketClient:
     """Base class for a client that interacts with a bucket-based storage system."""
 
+    def recreate(self, **kwargs) -> None:
+        """Recreate any underlying bucket client adapter with the given kwargs"""
+        pass
+
     def open(
         self,
         path: "Pathy",
@@ -140,6 +144,10 @@ class BucketClient:
         errors: Optional[str] = None,
         newline: Optional[str] = None,
     ) -> StreamableType:
+        client_params = {}
+        if hasattr(self, "client_params"):
+            client_params = getattr(self, "client_params")
+
         return smart_open.open(
             self.make_uri(path),
             mode=mode,
@@ -147,6 +155,7 @@ class BucketClient:
             encoding=encoding,
             errors=errors,
             newline=newline,
+            transport_params=client_params,
             # Disable de/compression based on the file extension
             ignore_ext=True,
         )  # type:ignore

--- a/pathy/base.py
+++ b/pathy/base.py
@@ -483,11 +483,13 @@ class Pathy(Path, PurePathy):
         return of this function to the desired type, e.g.
 
         ```python
-        fluid_path = FluidPath("gs://my_bucket/foo.txt")
+        from pathy import FluidPath, Pathy
+
+        fluid_path: FluidPath = Pathy.fluid("gs://my_bucket/foo.txt")
         # Narrow the type to a specific class
         assert isinstance(fluid_path, Pathy), "must be Pathy"
         # Use a member specific to that class
-        print(fluid_path.prefix)
+        assert fluid_path.prefix == "foo.txt/"
         ```
         """
         from_path: FluidPath = Pathy(path_candidate)
@@ -501,6 +503,8 @@ class Pathy(Path, PurePathy):
         the appropriate prefix.
 
         ```python
+        from pathy import Pathy
+
         assert str(Pathy.from_bucket("one")) == "gs://one/"
         assert str(Pathy.from_bucket("two")) == "gs://two/"
         ```
@@ -666,6 +670,8 @@ class Pathy(Path, PurePathy):
         """Resolve the given path to remove any relative path specifiers.
 
         ```python
+        from pathy import Pathy
+
         path = Pathy("gs://my_bucket/folder/../blob")
         assert path.resolve() == Pathy("gs://my_bucket/blob")
         ```

--- a/pathy/base.py
+++ b/pathy/base.py
@@ -130,9 +130,8 @@ class Bucket:
 class BucketClient:
     """Base class for a client that interacts with a bucket-based storage system."""
 
-    def recreate(self, **kwargs) -> None:
+    def recreate(self, **kwargs: Any) -> None:
         """Recreate any underlying bucket client adapter with the given kwargs"""
-        pass
 
     def open(
         self,

--- a/pathy/clients.py
+++ b/pathy/clients.py
@@ -16,6 +16,8 @@ _client_registry: Dict[str, Type[BucketClient]] = {
     "gs": BucketClientGCS,
 }
 
+# Hold given client args for a scheme
+_client_args_registry: Dict[str, Any] = {}
 _instance_cache: Dict[str, Any] = {}
 _fs_client: Optional[BucketClientFS] = None
 _fs_cache: Optional[pathlib.Path] = None
@@ -28,15 +30,29 @@ def register_client() -> None:
 
 def get_client(scheme: str) -> BucketClientType:
     """Retrieve the bucket client for use with a given scheme"""
-    global _client_registry, _instance_cache, _fs_client
+    global _client_registry, _instance_cache, _fs_client, _client_args_registry
     if _fs_client is not None:
         return _fs_client  # type: ignore
     if scheme in _instance_cache:
         return _instance_cache[scheme]
     elif scheme in _client_registry:
-        _instance_cache[scheme] = _client_registry[scheme]()
+        kwargs = (
+            _client_args_registry[scheme] if scheme in _client_args_registry else {}
+        )
+        _instance_cache[scheme] = _client_registry[scheme](**kwargs)  # type:ignore
         return _instance_cache[scheme]
     raise ValueError(f'There is no client registered to handle "{scheme}" paths')
+
+
+def set_client_params(scheme: str, **kwargs) -> None:
+    """Specify args to pass when instantiating a service-specific Client
+    object. This allows for passing credentials in whatever way your underlying
+    client library prefers."""
+    global _client_registry, _instance_cache, _client_args_registry
+    _client_args_registry[scheme] = kwargs
+    if scheme in _instance_cache:
+        _instance_cache[scheme].recreate(**_client_args_registry[scheme])
+    return None
 
 
 def use_fs(

--- a/pathy/clients.py
+++ b/pathy/clients.py
@@ -44,7 +44,7 @@ def get_client(scheme: str) -> BucketClientType:
     raise ValueError(f'There is no client registered to handle "{scheme}" paths')
 
 
-def set_client_params(scheme: str, **kwargs) -> None:
+def set_client_params(scheme: str, **kwargs: Any) -> None:
     """Specify args to pass when instantiating a service-specific Client
     object. This allows for passing credentials in whatever way your underlying
     client library prefers."""

--- a/pathy/clients.py
+++ b/pathy/clients.py
@@ -23,9 +23,10 @@ _fs_client: Optional[BucketClientFS] = None
 _fs_cache: Optional[pathlib.Path] = None
 
 
-def register_client() -> None:
+def register_client(scheme: str, type: Type[BucketClient]) -> None:
     """Register a bucket client for use with certain scheme Pathy objects"""
     global _client_registry
+    _client_registry[scheme] = type
 
 
 def get_client(scheme: str) -> BucketClientType:

--- a/pathy/gcs.py
+++ b/pathy/gcs.py
@@ -99,9 +99,19 @@ class BucketGCS(Bucket):
 class BucketClientGCS(BucketClient):
     client: Optional[GCSNativeClient]
 
-    def __init__(self, client: Optional[GCSNativeClient] = None):
+    @property
+    def client_params(self) -> Any:
+        return dict(client=self.client)
+
+    def __init__(self, **kwargs):
+        self.recreate(**kwargs)
+
+    def recreate(self, **kwargs) -> None:
         try:
-            self.client = GCSNativeClient() if GCSNativeClient else None
+            creds = kwargs["credentials"] if "credentials" in kwargs else None
+            if creds is not None:
+                kwargs["project"] = creds.project_id
+            self.client = GCSNativeClient(**kwargs) if GCSNativeClient else None
         except (BaseException, DefaultCredentialsError):
             self.client = None
 

--- a/pathy/gcs.py
+++ b/pathy/gcs.py
@@ -103,10 +103,10 @@ class BucketClientGCS(BucketClient):
     def client_params(self) -> Any:
         return dict(client=self.client)
 
-    def __init__(self, **kwargs):
+    def __init__(self, **kwargs: Any) -> None:
         self.recreate(**kwargs)
 
-    def recreate(self, **kwargs) -> None:
+    def recreate(self, **kwargs: Any) -> None:
         try:
             creds = kwargs["credentials"] if "credentials" in kwargs else None
             if creds is not None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+import json
 import os
 import shutil
 import tempfile
@@ -6,10 +7,10 @@ from pathlib import Path
 import pytest
 
 from pathy import Pathy, use_fs, use_fs_cache
+from pathy.clients import set_client_params
 from pathy.gcs import has_gcs
 
-# TODO: set this up with a service account for the CI
-has_credentials = "CI" not in os.environ
+has_credentials = "GCS_CREDENTIALS" in os.environ
 
 # Which adapters to use
 TEST_ADAPTERS = ["gcs", "fs"] if has_credentials and has_gcs else ["fs"]
@@ -39,12 +40,47 @@ def with_fs(temp_folder):
     use_fs(False)
 
 
+def credentials_from_env():
+    """Extract a credentials instance from the GCS_CREDENTIALS env variable.
+
+    You can specify the contents of a credentials JSON file or a file path
+    that points to a JSON file.
+
+    Raises AssertionError if the value is present but does not point to a file
+    or valid JSON content."""
+    if not has_gcs:
+        return None
+
+    creds = os.environ.get("GCS_CREDENTIALS", None)
+    if creds is None:
+        return None
+    from google.oauth2 import service_account
+
+    # If not a file path, assume it's JSON content
+    if Path(creds).is_file():
+        credentials = service_account.Credentials.from_service_account_file(creds)
+    else:
+        assert json.loads(creds) is not None, "expected a file or JSON blob"
+        fd, path = tempfile.mkstemp()
+        try:
+            with os.fdopen(fd, "w") as tmp:
+                tmp.write(creds)
+            credentials = service_account.Credentials.from_service_account_file(path)
+        finally:
+            os.remove(path)
+    return credentials
+
+
 @pytest.fixture()
 def with_adapter(adapter: str, bucket: str, other_bucket: str):
     tmp_dir = None
+    scheme = "gs"
     if adapter == "gcs":
-        # Use GCS (with system credentials)
+        # Use GCS
         use_fs(False)
+        credentials = credentials_from_env()
+        if credentials is not None:
+            set_client_params("gs", credentials=credentials)
     elif adapter == "fs":
         # Use local file-system in a temp folder
         tmp_dir = tempfile.mkdtemp()
@@ -58,7 +94,7 @@ def with_adapter(adapter: str, bucket: str, other_bucket: str):
     else:
         raise ValueError("invalid adapter, nothing is configured")
     # execute the test
-    yield
+    yield scheme
 
     if adapter == "fs" and tmp_dir is not None:
         # Cleanup fs temp folder

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -56,15 +56,20 @@ def credentials_from_env():
         return None
     from google.oauth2 import service_account
 
+    json_creds = None
+    try:
+        json_creds = json.loads(creds)
+    except json.decoder.JSONDecodeError:
+        pass
+
     # If not a file path, assume it's JSON content
-    if Path(creds).is_file():
+    if json_creds is None:
         credentials = service_account.Credentials.from_service_account_file(creds)
     else:
-        assert json.loads(creds) is not None, "expected a file or JSON blob"
         fd, path = tempfile.mkstemp()
         try:
             with os.fdopen(fd, "w") as tmp:
-                tmp.write(creds)
+                tmp.write(json.dumps(json_creds))
             credentials = service_account.Credentials.from_service_account_file(path)
         finally:
             os.remove(path)

--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -95,6 +95,9 @@ def test_api_use_fs_cache(with_adapter, with_fs: str, bucket: str):
 
 class BucketClientTest(BucketClient):
     def __init__(self, required_arg: bool) -> None:
+        self.recreate(required_arg=required_arg)
+
+    def recreate(self, required_arg: bool) -> None:
         self.required_arg = required_arg
 
 
@@ -105,4 +108,14 @@ def test_clients_set_client_params():
 
     set_client_params("test", required_arg=True)
     client = get_client("test")
+    assert isinstance(client, BucketClientTest)
+
+
+def test_clients_set_client_params_recreates_client():
+    register_client("test", BucketClientTest)
+    set_client_params("test", required_arg=False)
+    client: BucketClientTest = get_client("test")
+    assert client.required_arg is False
+    set_client_params("test", required_arg=True)
+    assert client.required_arg is True
     assert isinstance(client, BucketClientTest)

--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -1,12 +1,17 @@
-from pathy.base import BucketClient
-from pathy.clients import register_client, set_client_params
 import time
 from pathlib import Path
 
 import pytest
 
 from pathy import Pathy, get_client
-from pathy.clients import get_fs_client, use_fs, use_fs_cache
+from pathy.base import BucketClient
+from pathy.clients import (
+    get_fs_client,
+    register_client,
+    set_client_params,
+    use_fs,
+    use_fs_cache,
+)
 from pathy.file import BucketClientFS
 from pathy.gcs import BucketClientGCS
 

--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -84,7 +84,7 @@ def test_api_use_fs_cache(with_adapter, with_fs: str, bucket: str):
     assert orig_cache_time == cached_cache_time, "cached blob timestamps should match"
 
     # Update the blob
-    time.sleep(0.1)
+    time.sleep(1.0)
     path.write_text('{ "cool" : true }')
 
     # Fetch the updated blob

--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -22,6 +22,7 @@ def test_clients_get_client_works_with_builtin_schems():
 def test_clients_get_client_respects_use_fs_override():
     use_fs(True)
     assert isinstance(get_client("gs"), BucketClientFS)
+    use_fs(False)
 
 
 def test_clients_get_client_errors_with_unknown_scheme():

--- a/tools/docs.sh
+++ b/tools/docs.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 . .env/bin/activate
-mathy_pydoc pathy.Pathy+ pathy.BlobStat+ pathy.use_fs pathy.get_fs_client pathy.use_fs_cache pathy.get_fs_cache > /tmp/pathy_api.md
+mathy_pydoc pathy.Pathy+ pathy.BlobStat+ pathy.use_fs pathy.get_fs_client pathy.use_fs_cache pathy.get_fs_cache pathy.set_client_params > /tmp/pathy_api.md
 typer pathy.cli utils docs > /tmp/pathy_cli.md
 
 python tools/docs.py /tmp/pathy_api.md /tmp/pathy_cli.md README.md

--- a/tools/setup.sh
+++ b/tools/setup.sh
@@ -12,5 +12,5 @@ echo "Installing/updating requirements..."
 pip install -r requirements.txt
 echo "Installing/updating  dev requirements..."
 pip install -r requirements-dev.txt
-pip install -e .
+pip install -e ".[all]"
 


### PR DESCRIPTION
This PR adds support for passing implementation-specific args to the underlying bucket-client library. It's not normally required for usage, but allows fine-grained client initialization for cases where you need.

 - useful for passing credentials and other args to the underlying bucket client library