### PR TITLE
add requirements.txt to distributions

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,3 +2,4 @@ include setup.py
 include README.md
 include LICENSE
 include pathy/py.typed
+include requirements.txt


### PR DESCRIPTION
Hi folks, thanks for `pathy`!

It looks like `setup.py` needs `requirements.txt` to be distributed in order to install from source. This just adds it to `MANIFEST.in`!