### PR TITLE
Feature/ls

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,8 +83,8 @@ Returns True if the path points to an existing bucket, blob, or prefix.
 
 ```python (doc)
 Pathy.fluid(
-    path_candidate: Union[str, Pathy, pathlib.Path],
-) -> Union[Pathy, pathlib.Path]
+    path_candidate: Union[str, Pathy, BasePath],
+) -> Union[Pathy, BasePath]
 ```
 
 Infer either a Pathy or pathlib.Path from an input path or string.
@@ -167,6 +167,19 @@ Pathy.iterdir(
 ```
 
 Iterate over the blobs found in the given bucket or blob prefix path.
+
+## ls <kbd>method</kbd>
+
+```python (doc)
+Pathy.ls(self: 'Pathy') -> Generator[BlobStat, NoneType, NoneType]
+```
+
+List blob names with stat information under the given path.
+
+This is considerably faster than using iterdir if you also need
+the stat information for the enumerated blobs.
+
+Yields BlobStat objects for each found blob.
 
 ## mkdir <kbd>method</kbd>
 
@@ -327,6 +340,7 @@ FileExistsError is raised.
 ```python (doc)
 BlobStat(
     self,
+    name: str,
     size: Optional[int],
     last_modified: Optional[int],
 ) -> None

--- a/README.md
+++ b/README.md
@@ -458,6 +458,7 @@ $ ls [OPTIONS] LOCATION
 
 **Options**:
 
+- `-l, --long`: Print long style entries with updated time and size shown. [default: False]
 - `--help`: Show this message and exit.
 
 ## `mv`

--- a/pathy/__init__.py
+++ b/pathy/__init__.py
@@ -1,4 +1,5 @@
 from .base import (
+    BasePath,
     Blob,
     BlobStat,
     Bucket,

--- a/pathy/base.py
+++ b/pathy/base.py
@@ -25,7 +25,7 @@ import smart_open
 SUBCLASS_ERROR = "must be implemented in a subclass"
 
 StreamableType = IO[Any]
-FluidPath = Union["Pathy", Path]
+FluidPath = Union["Pathy", "BasePath"]
 BucketClientType = TypeVar("BucketClientType", bound="BucketClient")
 BucketType = TypeVar("BucketType")
 BucketBlobType = TypeVar("BucketBlobType")
@@ -47,6 +47,7 @@ class ClientError(BaseException):
 class BlobStat:
     """Stat for a bucket item"""
 
+    name: str
     size: Optional[int]
     last_modified: Optional[int]
 
@@ -86,7 +87,7 @@ class BucketEntry(Generic[BucketType, BucketBlobType]):
         self.name = name
         self.raw = raw
         self._is_dir = is_dir
-        self._stat = BlobStat(size=size, last_modified=last_modified)
+        self._stat = BlobStat(name=name, size=size, last_modified=last_modified)
 
     def __repr__(self) -> str:
         return "{}(name={}, is_dir={}, stat={})".format(
@@ -303,6 +304,24 @@ class PurePathy(PurePath):
 _SUPPORTED_OPEN_MODES = {"r", "rb", "tr", "rt", "w", "wb", "bw", "wt", "tw"}
 
 
+class _PathyExtensions:
+    def ls(self) -> Generator["BlobStat", None, None]:
+        blobs: "PathyScanDir" = self._accessor.scandir(self)  # type:ignore
+        for blob in blobs:
+            if hasattr(blob, "_stat"):
+                yield blob._stat
+            elif isinstance(blob, os.DirEntry):
+                os_blob = cast(os.DirEntry, blob)
+                stat = os_blob.stat()
+                file_size = stat.st_size
+                updated = int(round(stat.st_mtime))
+                yield BlobStat(name=os_blob.name, size=file_size, last_modified=updated)
+
+
+class BasePath(Path, _PathyExtensions):
+    _flavour = _PosixFlavour()
+
+
 class BucketsAccessor(_Accessor):
     """Access data from blob buckets"""
 
@@ -337,7 +356,7 @@ class BucketsAccessor(_Accessor):
         blob: Optional[Blob] = bucket.get_blob(str(path.key))
         if blob is None:
             raise FileNotFoundError(path)
-        return BlobStat(size=blob.size, last_modified=blob.updated)
+        return BlobStat(name=str(blob), size=blob.size, last_modified=blob.updated)
 
     def is_dir(self, path: "Pathy") -> bool:
         if str(path) == path.root:
@@ -453,7 +472,7 @@ class BucketsAccessor(_Accessor):
                 raise OSError(f"Blob already exists: {path}")
 
 
-class Pathy(Path, PurePathy):
+class Pathy(Path, PurePathy, _PathyExtensions):
     """Subclass of `pathlib.Path` that works with bucket APIs."""
 
     __slots__ = ()
@@ -497,7 +516,7 @@ class Pathy(Path, PurePathy):
         """
         from_path: FluidPath = Pathy(path_candidate)
         if from_path.root in ["/", ""]:
-            from_path = Path(path_candidate)
+            from_path = BasePath(path_candidate)
         return from_path
 
     @classmethod
@@ -570,6 +589,16 @@ class Pathy(Path, PurePathy):
                 for blob in in_path.rglob("*"):
                     Pathy.to_local(blob, recurse=False)
         return cache_blob
+
+    def ls(self: "Pathy") -> Generator["BlobStat", None, None]:
+        """List blob names with stat information under the given path.
+
+        This is considerably faster than using iterdir if you also need
+        the stat information for the enumerated blobs.
+
+        Yields BlobStat objects for each found blob.
+        """
+        yield from super(Pathy, self).ls()
 
     def stat(self: "Pathy") -> BlobStat:  # type: ignore[override]
         """Returns information about this bucket path."""

--- a/pathy/file.py
+++ b/pathy/file.py
@@ -64,7 +64,7 @@ class BucketFS(Bucket):
             name=blob_name,
             raw=native_blob,
             size=stat.st_size,
-            updated=int(round(stat.st_mtime_ns * 1000)),
+            updated=int(round(stat.st_mtime)),
         )
 
     def copy_blob(  # type:ignore[override]
@@ -257,7 +257,7 @@ class _FSScanDir(PathyScanDir):
                 file_path = pathlib.Path(dir_entry)
                 stat = file_path.stat()
                 file_size = stat.st_size
-                updated = int(round(stat.st_mtime_ns * 1000))
+                updated = int(round(stat.st_mtime))
                 blob: Blob = BlobFS(
                     self._client.get_bucket(self._path),
                     name=dir_entry.name,

--- a/pathy/tests/test_base.py
+++ b/pathy/tests/test_base.py
@@ -576,6 +576,19 @@ def test_api_readwrite_lines(with_adapter: str, bucket: str) -> None:
 
 
 @pytest.mark.parametrize("adapter", TEST_ADAPTERS)
+def test_api_ls_blobs_with_stat(with_adapter: str, bucket: str) -> None:
+    root = Pathy(f"gs://{bucket}/ls")
+    for i in range(3):
+        (root / f"file_{i}").write_text("NICE")
+    files = list(root.ls())
+    assert len(files) == 3
+    for i, blob_stat in enumerate(files):
+        assert blob_stat.name == f"file_{i}"
+        assert blob_stat.size == 4
+        assert blob_stat.last_modified is not None
+
+
+@pytest.mark.parametrize("adapter", TEST_ADAPTERS)
 def test_api_owner(with_adapter: str, bucket: str) -> None:
     # Raises for invalid file
     with pytest.raises(FileNotFoundError):

--- a/pathy/tests/test_base.py
+++ b/pathy/tests/test_base.py
@@ -8,6 +8,7 @@ import pytest
 import spacy
 
 from pathy import (
+    BasePath,
     Blob,
     BlobStat,
     Bucket,
@@ -332,9 +333,9 @@ def test_api_fluid(with_adapter: str, bucket: str) -> None:
     path: FluidPath = Pathy.fluid(f"gs://{bucket}/fake-key")
     assert isinstance(path, Pathy)
     path = Pathy.fluid("foo/bar.txt")
-    assert isinstance(path, Path)
+    assert isinstance(path, BasePath)
     path = Pathy.fluid("/dev/null")
-    assert isinstance(path, Path)
+    assert isinstance(path, BasePath)
 
 
 @pytest.mark.parametrize("adapter", TEST_ADAPTERS)

--- a/pathy/tests/test_cli.py
+++ b/pathy/tests/test_cli.py
@@ -161,7 +161,14 @@ def test_cli_ls(with_adapter: str, bucket: str) -> None:
     Pathy(one).write_text("---")
     Pathy(two).write_text("---")
     Pathy(three).write_text("---")
+
     result = runner.invoke(app, ["ls", str(root)])
+    assert result.exit_code == 0
+    assert one in result.output
+    assert two in result.output
+    assert str(root / "folder") in result.output
+
+    result = runner.invoke(app, ["ls", "-l", str(root)])
     assert result.exit_code == 0
     assert one in result.output
     assert two in result.output


### PR DESCRIPTION
### Problem
When listing a large number of blobs and their changed time / size attributes, performance is not great. This is because when dealing with remote systems like GCS, the `stat` operation is slow when executed a bunch of times. Consider the following code that is **fast** at enumerating large numbers of files/stats on local systems but **slow** for remote GCS buckets.

```python
from pathy import Pathy

files = Pathy("gs://my_bucket/images")
for file in files.iterdir():
    stat = file.stat()
    print(f"{file.name}, {stat.size}, {stat.last_modified}")
```

The trouble is that we have to make requests to get the file listings, and then extra requests for each blob to get the stat information. If you have hundreds or thousands of blobs this gets quite slow.

### Solution

Add a helper method `ls` that does not exist in the standard pathlib.Path interface. This yields blobs and their size/time stats with a single-pass, and ends up being much quicker than the above example when dealing with remote storage. The example above would now be more appropriately implemented as:

```python
files = Pathy("gs://my_bucket/images")
for file in files.ls():
    print(f"{file.name}, {file.size}, {file.last_modified}")
```

### Changes

Add an `ls` method to `Pathy` objects. To provide a consistent API, `Pathy.fluid` now returns a `pathy.BasePath` object when dealing with local files. This class is a light wrapper on top of `pathlib.Path` that adds the pathy specific methods like `ls`.

Add a long-form `-l` flag to the cli's `ls` command that prints blob size and updated time stats next to their names.
