### PR TITLE
fix(gcs): stop handling DefaultCredentialsError

### DIFF
--- a/pathy/__init__.py
+++ b/pathy/__init__.py
@@ -21,4 +21,4 @@ from .clients import (
     use_fs_cache,
 )
 from .file import BlobFS, BucketClientFS, BucketEntryFS, BucketFS
-from .gcs import BlobGCS, BucketClientGCS, BucketEntryGCS, BucketGCS
+from .gcs import BlobGCS, BucketClientGCS, BucketEntryGCS, BucketGCS, has_gcs

--- a/pathy/gcs.py
+++ b/pathy/gcs.py
@@ -115,12 +115,14 @@ class BucketClientGCS(BucketClient):
         self.recreate(**kwargs)
 
     def recreate(self, **kwargs: Any) -> None:
+        creds = kwargs["credentials"] if "credentials" in kwargs else None
+        if creds is not None:
+            kwargs["project"] = creds.project_id
         try:
-            creds = kwargs["credentials"] if "credentials" in kwargs else None
-            if creds is not None:
-                kwargs["project"] = creds.project_id
-            self.client = GCSNativeClient(**kwargs) if GCSNativeClient else None
-        except (BaseException, DefaultCredentialsError):
+            self.client = GCSNativeClient(**kwargs)
+        except TypeError:
+            # TypeError is raised if the imports for GCSNativeClient fail and are
+            #  assigned to Any, which is not callable.
             self.client = None
 
     def make_uri(self, path: PurePathy) -> str:

--- a/pathy/tests/test_gcs.py
+++ b/pathy/tests/test_gcs.py
@@ -1,0 +1,24 @@
+from unittest.mock import patch
+
+import pytest
+
+from pathy import has_gcs, set_client_params
+
+
+def raise_default_creds_error() -> None:
+    from google.auth.exceptions import DefaultCredentialsError
+
+    raise DefaultCredentialsError()
+
+
+@pytest.mark.parametrize("adapter", ["gcs"])
+@patch("google.auth.default", raise_default_creds_error)
+@pytest.mark.skipif(not has_gcs, reason="requires gcs")
+def test_gcs_default_credentials_error_is_preserved(
+    with_adapter: str, bucket: str
+) -> None:
+    from google.auth.exceptions import DefaultCredentialsError
+
+    # Remove the default credentials (this will recreate the client and error)
+    with pytest.raises(DefaultCredentialsError):
+        set_client_params("gs")


### PR DESCRIPTION
 - google-cloud-storage provides a nice error message when it can't find the default credentials. Let it flow through to the client.
 - add test to ensure that if the default google creds can't be found, the error can be caught by the caller.
 - fixes #43