### PR TITLE
Feature/s3

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -29,6 +29,8 @@ jobs:
       - name: Test Wheel
         env:
           GCS_CREDENTIALS: ${{ secrets.GCS_CREDENTIALS }}
+          PATHY_S3_ACCESS_ID: ${{ secrets.PATHY_S3_ACCESS_ID }}
+          PATHY_S3_ACCESS_SECRET: ${{ secrets.PATHY_S3_ACCESS_SECRET }}
         run: rm -rf ./pathy/ && sh tools/test_package.sh
       - name: Report Code Coverage
         env:

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Pypi version](https://badgen.net/pypi/v/pathy)](https://pypi.org/project/pathy/)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/ambv/black)
 
-Pathy is a python package (_with type annotations_) for working with Bucket storage providers. It provides a CLI app for basic file operations between local files and remote buckets. It enables a smooth developer experience by supporting local file-system backed buckets during development and testing. It makes converting bucket blobs into local files a snap with optional local file caching of blobs.
+Pathy is a python package (_with type annotations_) for working with Cloud Bucket storage providers using a pathlib interface. It provides an easy-to-use API bundled with a CLI app for basic file operations between local files and remote buckets. It enables a smooth developer experience by letting developers work against the local file system during development and only switch over to live APIs for deployment. It also makes converting bucket blobs into local files a snap with optional local file caching.
 
 ## 🚀 Quickstart
 
@@ -15,7 +15,7 @@ You can install `pathy` from pip:
 pip install pathy
 ```
 
-The package exports the `Pathy` class and utilities for configuring the bucket storage provider to use. By default Pathy prefers GoogleCloudStorage paths of the form `gs://bucket_name/folder/blob_name.txt`. Internally Pathy can convert GCS paths to local files, allowing for a nice developer experience.
+The package exports the `Pathy` class and utilities for configuring the bucket storage provider to use.
 
 ```python
 from pathy import Pathy, use_fs
@@ -36,6 +36,16 @@ greeting.unlink()
 # Now it doesn't
 assert not greeting.exists()
 ```
+
+## Supported Clouds
+
+The table below details the supported cloud provider APIs.
+
+| Cloud Service        | Support |      Install Extras      |
+| :------------------- | :-----: | :----------------------: |
+| Google Cloud Storage |   ✅    | `pip install pathy[gcs]` |
+| Amazon S3            |   ✅    | `pip install pathy[s3]`  |
+| Azure                |   ❌    |                          |
 
 ## Semantic Versioning
 

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ assert fluid_path.prefix == "foo.txt/"
 ## from_bucket <kbd>classmethod</kbd>
 
 ```python (doc)
-Pathy.from_bucket(bucket_name: str) -> 'Pathy'
+Pathy.from_bucket(bucket_name: str, scheme: str = 'gs') -> 'Pathy'
 ```
 
 Initialize a Pathy from a bucket name. This helper adds a trailing slash and

--- a/pathy/__init__.py
+++ b/pathy/__init__.py
@@ -516,7 +516,7 @@ class Pathy(Path, PurePathy, _PathyExtensions):
         return from_path
 
     @classmethod
-    def from_bucket(cls, bucket_name: str, scheme:str = "gs") -> "Pathy":
+    def from_bucket(cls, bucket_name: str, scheme: str = "gs") -> "Pathy":
         """Initialize a Pathy from a bucket name. This helper adds a trailing slash and
         the appropriate prefix.
 

--- a/pathy/__init__.py
+++ b/pathy/__init__.py
@@ -366,7 +366,7 @@ class BucketsAccessor(_Accessor):  # type:ignore
         blob: Optional[Blob] = bucket.get_blob(str(path.key))
         if blob is None:
             raise FileNotFoundError(path)
-        return BlobStat(name=str(blob), size=blob.size, last_modified=blob.updated)
+        return BlobStat(name=str(blob.name), size=blob.size, last_modified=blob.updated)
 
     def is_dir(self, path: "Pathy") -> bool:
         if self.get_blob(path) is not None:
@@ -516,7 +516,7 @@ class Pathy(Path, PurePathy, _PathyExtensions):
         return from_path
 
     @classmethod
-    def from_bucket(cls, bucket_name: str) -> "Pathy":
+    def from_bucket(cls, bucket_name: str, scheme:str = "gs") -> "Pathy":
         """Initialize a Pathy from a bucket name. This helper adds a trailing slash and
         the appropriate prefix.
 
@@ -527,7 +527,7 @@ class Pathy(Path, PurePathy, _PathyExtensions):
         assert str(Pathy.from_bucket("two")) == "gs://two/"
         ```
         """
-        return Pathy(f"gs://{bucket_name}/")  # type:ignore
+        return Pathy(f"{scheme}://{bucket_name}/")  # type:ignore
 
     @classmethod
     def to_local(cls, blob_path: Union["Pathy", str], recurse: bool = True) -> Path:
@@ -1159,6 +1159,7 @@ _client_registry: Dict[str, Type[BucketClient]] = {
 # a Pathy object with a matching scheme
 _optional_clients: Dict[str, str] = {
     "gs": "pathy.gcs",
+    "s3": "pathy.s3",
 }
 BucketClientType = TypeVar("BucketClientType", bound=BucketClient)
 

--- a/pathy/_tests/__init__.py
+++ b/pathy/_tests/__init__.py
@@ -5,3 +5,11 @@ try:
     has_gcs = bool(BucketClientGCS)
 except ImportError:
     has_gcs = False
+
+has_s3: bool
+try:
+    from ..s3 import BucketClientS3
+
+    has_s3 = bool(BucketClientS3)
+except ImportError:
+    has_s3 = False

--- a/pathy/_tests/conftest.py
+++ b/pathy/_tests/conftest.py
@@ -112,8 +112,8 @@ def with_adapter(
         use_fs(False)
         credentials = s3_credentials_from_env()
         if credentials is not None:
-            # key_id, key_secret = credentials
-            set_client_params("s3", credentials=credentials)
+            key_id, key_secret = credentials
+            set_client_params("s3", key_id=key_id, key_secret=key_secret)
     elif adapter == "fs":
         # Use local file-system in a temp folder
         tmp_dir = tempfile.mkdtemp()

--- a/pathy/_tests/conftest.py
+++ b/pathy/_tests/conftest.py
@@ -15,7 +15,7 @@ from . import has_gcs
 has_credentials = "GCS_CREDENTIALS" in os.environ
 
 # Which adapters to use
-TEST_ADAPTERS = ["gcs", "s3", "fs"] if has_credentials and has_gcs else ["s3"]
+TEST_ADAPTERS = ["gcs", "s3", "fs"] if has_credentials and has_gcs else ["fs"]
 # A unique identifier used to allow each python version and OS to test
 # with separate bucket paths. This makes it possible to parallelize the
 # tests.

--- a/pathy/_tests/test_cli.py
+++ b/pathy/_tests/test_cli.py
@@ -17,16 +17,16 @@ runner = CliRunner()
 
 @pytest.mark.parametrize("adapter", TEST_ADAPTERS)
 def test_cli_cp_invalid_from_path(with_adapter: str, bucket: str) -> None:
-    source = f"gs://{bucket}/{ENV_ID}/cli_cp_file_invalid/file.txt"
-    destination = f"gs://{bucket}/{ENV_ID}/cli_cp_file_invalid/dest.txt"
+    source = f"{with_adapter}://{bucket}/{ENV_ID}/cli_cp_file_invalid/file.txt"
+    destination = f"{with_adapter}://{bucket}/{ENV_ID}/cli_cp_file_invalid/dest.txt"
     assert runner.invoke(app, ["cp", source, destination]).exit_code == 1
     assert not Pathy(destination).is_file()
 
 
 @pytest.mark.parametrize("adapter", TEST_ADAPTERS)
 def test_cli_cp_file(with_adapter: str, bucket: str) -> None:
-    source = f"gs://{bucket}/{ENV_ID}/cli_cp_file/file.txt"
-    destination = f"gs://{bucket}/{ENV_ID}/cli_cp_file/other.txt"
+    source = f"{with_adapter}://{bucket}/{ENV_ID}/cli_cp_file/file.txt"
+    destination = f"{with_adapter}://{bucket}/{ENV_ID}/cli_cp_file/other.txt"
     Pathy(source).write_text("---")
     assert runner.invoke(app, ["cp", source, destination]).exit_code == 0
     assert Pathy(source).exists()
@@ -37,7 +37,7 @@ def test_cli_cp_file(with_adapter: str, bucket: str) -> None:
 def test_cli_cp_file_name_from_source(with_adapter: str, bucket: str) -> None:
     source = pathlib.Path("./file.txt")
     source.touch()
-    destination = f"gs://{bucket}/{ENV_ID}/cli_cp_file/"
+    destination = f"{with_adapter}://{bucket}/{ENV_ID}/cli_cp_file/"
     assert runner.invoke(app, ["cp", str(source), destination]).exit_code == 0
     assert Pathy(f"{destination}file.txt").is_file()
     source.unlink()
@@ -45,7 +45,7 @@ def test_cli_cp_file_name_from_source(with_adapter: str, bucket: str) -> None:
 
 @pytest.mark.parametrize("adapter", TEST_ADAPTERS)
 def test_cli_cp_folder(with_adapter: str, bucket: str) -> None:
-    root = Pathy.from_bucket(bucket) / ENV_ID
+    root = Pathy(f"{with_adapter}://{bucket}/{ENV_ID}/")
     source = root / "cli_cp_folder"
     destination = root / "cli_cp_folder_other"
     for i in range(2):
@@ -61,7 +61,7 @@ def test_cli_cp_folder(with_adapter: str, bucket: str) -> None:
 
 @pytest.mark.parametrize("adapter", TEST_ADAPTERS)
 def test_cli_mv_folder(with_adapter: str, bucket: str) -> None:
-    root = Pathy.from_bucket(bucket) / ENV_ID
+    root = Pathy(f"{with_adapter}://{bucket}/{ENV_ID}/")
     source = root / "cli_mv_folder"
     destination = root / "cli_mv_folder_other"
     for i in range(2):
@@ -84,7 +84,7 @@ def test_cli_mv_folder(with_adapter: str, bucket: str) -> None:
 def test_cli_mv_file_copy_from_name(with_adapter: str, bucket: str) -> None:
     source = pathlib.Path("./file.txt")
     source.touch()
-    destination = f"gs://{bucket}/{ENV_ID}/cli_cp_file/"
+    destination = f"{with_adapter}://{bucket}/{ENV_ID}/cli_cp_file/"
     assert runner.invoke(app, ["mv", str(source), destination]).exit_code == 0
     assert Pathy(f"{destination}file.txt").is_file()
     # unlink should happen from the operation
@@ -93,8 +93,8 @@ def test_cli_mv_file_copy_from_name(with_adapter: str, bucket: str) -> None:
 
 @pytest.mark.parametrize("adapter", TEST_ADAPTERS)
 def test_cli_mv_file(with_adapter: str, bucket: str) -> None:
-    source = f"gs://{bucket}/{ENV_ID}/cli_mv_file/file.txt"
-    destination = f"gs://{bucket}/{ENV_ID}/cli_mv_file/other.txt"
+    source = f"{with_adapter}://{bucket}/{ENV_ID}/cli_mv_file/file.txt"
+    destination = f"{with_adapter}://{bucket}/{ENV_ID}/cli_mv_file/other.txt"
     Pathy(source).write_text("---")
     assert Pathy(source).exists()
     assert runner.invoke(app, ["mv", source, destination]).exit_code == 0
@@ -106,8 +106,10 @@ def test_cli_mv_file(with_adapter: str, bucket: str) -> None:
 def test_cli_mv_file_across_buckets(
     with_adapter: str, bucket: str, other_bucket: str
 ) -> None:
-    source = f"gs://{bucket}/{ENV_ID}/cli_mv_file_across_buckets/file.txt"
-    destination = f"gs://{other_bucket}/{ENV_ID}/cli_mv_file_across_buckets/other.txt"
+    source = f"{with_adapter}://{bucket}/{ENV_ID}/cli_mv_file_across_buckets/file.txt"
+    destination = (
+        f"{with_adapter}://{other_bucket}/{ENV_ID}/cli_mv_file_across_buckets/other.txt"
+    )
     Pathy(source).write_text("---")
     assert Pathy(source).exists()
     assert runner.invoke(app, ["mv", source, destination]).exit_code == 0
@@ -119,9 +121,9 @@ def test_cli_mv_file_across_buckets(
 def test_cli_mv_folder_across_buckets(
     with_adapter: str, bucket: str, other_bucket: str
 ) -> None:
-    source = Pathy.from_bucket(bucket) / ENV_ID / "cli_mv_folder_across_buckets"
-    destination = (
-        Pathy.from_bucket(other_bucket) / ENV_ID / "cli_mv_folder_across_buckets"
+    source = Pathy(f"{with_adapter}://{bucket}/{ENV_ID}/cli_mv_folder_across_buckets")
+    destination = Pathy(
+        f"{with_adapter}://{other_bucket}/{ENV_ID}/cli_mv_folder_across_buckets"
     )
     for i in range(2):
         for j in range(2):
@@ -141,7 +143,7 @@ def test_cli_mv_folder_across_buckets(
 
 @pytest.mark.parametrize("adapter", TEST_ADAPTERS)
 def test_cli_rm_invalid_file(with_adapter: str, bucket: str) -> None:
-    source = f"gs://{bucket}/{ENV_ID}/cli_rm_file_invalid/file.txt"
+    source = f"{with_adapter}://{bucket}/{ENV_ID}/cli_rm_file_invalid/file.txt"
     path = Pathy(source)
     assert not path.exists()
     assert runner.invoke(app, ["rm", source]).exit_code == 1
@@ -149,7 +151,7 @@ def test_cli_rm_invalid_file(with_adapter: str, bucket: str) -> None:
 
 @pytest.mark.parametrize("adapter", TEST_ADAPTERS)
 def test_cli_rm_file(with_adapter: str, bucket: str) -> None:
-    source = f"gs://{bucket}/{ENV_ID}/cli_rm_file/file.txt"
+    source = f"{with_adapter}://{bucket}/{ENV_ID}/cli_rm_file/file.txt"
     path = Pathy(source)
     path.write_text("---")
     assert path.exists()
@@ -159,7 +161,7 @@ def test_cli_rm_file(with_adapter: str, bucket: str) -> None:
 
 @pytest.mark.parametrize("adapter", TEST_ADAPTERS)
 def test_cli_rm_verbose(with_adapter: str, bucket: str) -> None:
-    root = Pathy.from_bucket(bucket) / ENV_ID / "cli_rm_folder"
+    root = Pathy(f"{with_adapter}://{bucket}/{ENV_ID}/") / "cli_rm_folder"
     source = str(root / "file.txt")
     other = str(root / "folder/other")
     Pathy(source).write_text("---")
@@ -178,7 +180,7 @@ def test_cli_rm_verbose(with_adapter: str, bucket: str) -> None:
 
 @pytest.mark.parametrize("adapter", TEST_ADAPTERS)
 def test_cli_rm_folder(with_adapter: str, bucket: str) -> None:
-    root = Pathy.from_bucket(bucket) / ENV_ID
+    root = Pathy(f"{with_adapter}://{bucket}/{ENV_ID}/")
     source = root / "cli_rm_folder"
     for i in range(2):
         for j in range(2):
@@ -196,7 +198,7 @@ def test_cli_rm_folder(with_adapter: str, bucket: str) -> None:
 
 @pytest.mark.parametrize("adapter", TEST_ADAPTERS)
 def test_cli_ls_invalid_source(with_adapter: str, bucket: str) -> None:
-    root = Pathy.from_bucket(bucket) / ENV_ID / "cli_ls_invalid"
+    root = Pathy(f"{with_adapter}://{bucket}/{ENV_ID}/") / "cli_ls_invalid"
     three = str(root / "folder/file.txt")
 
     result = runner.invoke(app, ["ls", str(three)])
@@ -206,7 +208,7 @@ def test_cli_ls_invalid_source(with_adapter: str, bucket: str) -> None:
 
 @pytest.mark.parametrize("adapter", TEST_ADAPTERS)
 def test_cli_ls(with_adapter: str, bucket: str) -> None:
-    root = Pathy.from_bucket(bucket) / ENV_ID / "cli_ls"
+    root = Pathy(f"{with_adapter}://{bucket}/{ENV_ID}/") / "cli_ls"
     one = str(root / "file.txt")
     two = str(root / "other.txt")
     three = str(root / "folder/file.txt")
@@ -241,7 +243,7 @@ def test_cli_ls_local_files(with_adapter: str, bucket: str) -> None:
         assert blob_stat.size == 4
         assert blob_stat.last_modified is not None
 
-    root = Pathy.from_bucket(bucket) / ENV_ID / "cli_ls"
+    root = Pathy(f"{with_adapter}://{bucket}/{ENV_ID}/") / "cli_ls"
     one = str(root / "file.txt")
     two = str(root / "other.txt")
     three = str(root / "folder/file.txt")

--- a/pathy/_tests/test_clients.py
+++ b/pathy/_tests/test_clients.py
@@ -73,7 +73,7 @@ def test_clients_use_fs(with_fs: Path) -> None:
 
 @pytest.mark.parametrize("adapter", TEST_ADAPTERS)
 def test_api_use_fs_cache(with_adapter: str, with_fs: str, bucket: str) -> None:
-    path = Pathy(f"gs://{bucket}/{ENV_ID}/directory/foo.txt")
+    path = Pathy(f"{with_adapter}://{bucket}/{ENV_ID}/directory/foo.txt")
     path.write_text("---")
     assert isinstance(path, Pathy)
     with pytest.raises(ValueError):

--- a/pathy/_tests/test_gcs.py
+++ b/pathy/_tests/test_gcs.py
@@ -2,7 +2,7 @@ from unittest.mock import patch
 
 import pytest
 
-from pathy import Pathy, get_client, set_client_params
+from pathy import Pathy, get_client, set_client_params, use_fs
 
 from . import has_gcs
 
@@ -38,6 +38,7 @@ def test_gcs_as_uri(with_adapter: str, bucket: str) -> None:
 
 @pytest.mark.skipif(has_gcs, reason="requires gcs deps to NOT be installed")
 def test_gcs_import_error_missing_deps() -> None:
+    use_fs(False)
     with pytest.raises(ImportError):
         get_client("gs")
 
@@ -57,9 +58,7 @@ def test_gcs_scandir_list_buckets(
 
 @pytest.mark.parametrize("adapter", GCS_ADAPTER)
 @pytest.mark.skipif(not has_gcs, reason="requires gcs")
-def test_gcs_scandir_invalid_bucket_name(
-    with_adapter: str, bucket: str, other_bucket: str
-) -> None:
+def test_gcs_scandir_invalid_bucket_name(with_adapter: str) -> None:
     from pathy.gcs import ScanDirGCS
 
     root = Pathy("gs://invalid_h3gE_ds5daEf_Sdf15487t2n4/bar")

--- a/pathy/_tests/test_gcs.py
+++ b/pathy/_tests/test_gcs.py
@@ -4,7 +4,6 @@ import pytest
 
 from pathy import Pathy, get_client, set_client_params
 
-
 from . import has_gcs
 
 GCS_ADAPTER = ["gcs"]

--- a/pathy/_tests/test_s3.py
+++ b/pathy/_tests/test_s3.py
@@ -1,8 +1,8 @@
 import pytest
-
-from pathy import get_client
+from pathy import Pathy, get_client
 
 from . import has_s3
+from .conftest import ENV_ID
 
 S3_ADAPTER = ["s3"]
 
@@ -11,3 +11,56 @@ S3_ADAPTER = ["s3"]
 def test_s3_import_error_missing_deps() -> None:
     with pytest.raises(ImportError):
         get_client("s3")
+
+
+@pytest.mark.parametrize("adapter", S3_ADAPTER)
+@pytest.mark.skipif(not has_s3, reason="requires s3")
+def test_s3_scandir_list_buckets(
+    with_adapter: str, bucket: str, other_bucket: str
+) -> None:
+    from pathy.s3 import ScanDirS3
+
+    root = Pathy("s3://foo/bar")
+    client = root._accessor.client(root)  # type:ignore
+    scandir = ScanDirS3(client=client, path=Pathy())
+    buckets = [s.name for s in scandir]
+    assert bucket in buckets
+    assert other_bucket in buckets
+
+
+@pytest.mark.parametrize("adapter", S3_ADAPTER)
+@pytest.mark.skipif(not has_s3, reason="requires s3")
+def test_s3_scandir_scandir_continuation_token(
+    with_adapter: str, bucket: str, other_bucket: str
+) -> None:
+    from pathy.s3 import ScanDirS3
+
+    root = Pathy(f"{with_adapter}://{bucket}/{ENV_ID}/s3_scandir_pagination/")
+    for i in range(8):
+        (root / f"file{i}.blob").touch()
+    client = root._accessor.client(root)  # type:ignore
+    scandir = ScanDirS3(client=client, path=root, prefix=root.prefix, page_size=4)
+    blobs = [s.name for s in scandir]
+    assert len(blobs) == 8
+
+
+@pytest.mark.parametrize("adapter", S3_ADAPTER)
+@pytest.mark.skipif(not has_s3, reason="requires s3")
+def test_s3_scandir_invalid_bucket_name(with_adapter: str) -> None:
+    from pathy.s3 import ScanDirS3
+
+    root = Pathy(f"{with_adapter}://invalid_h3gE_ds5daEf_Sdf15487t2n4/bar")
+    client = root._accessor.client(root)  # type:ignore
+    scandir = ScanDirS3(client=client, path=root)
+    assert len(list(scandir)) == 0
+
+
+@pytest.mark.parametrize("adapter", S3_ADAPTER)
+@pytest.mark.skipif(not has_s3, reason="requires s3")
+def test_s3_bucket_client_list_blobs(with_adapter: str, bucket: str) -> None:
+    """Test corner-case in S3 client that isn't easily reachable from Pathy"""
+    from pathy.s3 import BucketClientS3
+
+    client: BucketClientS3 = get_client("s3")
+    root = Pathy("s3://invalid_h3gE_ds5daEf_Sdf15487t2n4")
+    assert len(list(client.list_blobs(root))) == 0

--- a/pathy/_tests/test_s3.py
+++ b/pathy/_tests/test_s3.py
@@ -2,7 +2,6 @@ import pytest
 
 from pathy import get_client
 
-
 from . import has_s3
 
 S3_ADAPTER = ["s3"]

--- a/pathy/_tests/test_s3.py
+++ b/pathy/_tests/test_s3.py
@@ -1,16 +1,11 @@
 import pytest
-from pathy import Pathy, get_client
+
+from pathy import Pathy, get_client, use_fs
 
 from . import has_s3
 from .conftest import ENV_ID
 
 S3_ADAPTER = ["s3"]
-
-
-@pytest.mark.skipif(has_s3, reason="requires s3 deps to NOT be installed")
-def test_s3_import_error_missing_deps() -> None:
-    with pytest.raises(ImportError):
-        get_client("s3")
 
 
 @pytest.mark.parametrize("adapter", S3_ADAPTER)
@@ -64,3 +59,10 @@ def test_s3_bucket_client_list_blobs(with_adapter: str, bucket: str) -> None:
     client: BucketClientS3 = get_client("s3")
     root = Pathy("s3://invalid_h3gE_ds5daEf_Sdf15487t2n4")
     assert len(list(client.list_blobs(root))) == 0
+
+
+@pytest.mark.skipif(has_s3, reason="requires s3 deps to NOT be installed")
+def test_s3_import_error_missing_deps() -> None:
+    use_fs(False)
+    with pytest.raises(ImportError):
+        get_client("s3")

--- a/pathy/_tests/test_s3.py
+++ b/pathy/_tests/test_s3.py
@@ -1,0 +1,14 @@
+import pytest
+
+from pathy import get_client
+
+
+from . import has_s3
+
+S3_ADAPTER = ["s3"]
+
+
+@pytest.mark.skipif(has_s3, reason="requires s3 deps to NOT be installed")
+def test_s3_import_error_missing_deps() -> None:
+    with pytest.raises(ImportError):
+        get_client("s3")

--- a/pathy/s3.py
+++ b/pathy/s3.py
@@ -1,0 +1,246 @@
+from dataclasses import dataclass
+from typing import Any, Dict, Generator, List, Optional
+
+
+try:
+    import boto3  # type:ignore
+    from botocore.exceptions import ParamValidationError
+    from botocore.client import ClientError
+
+    S3NativeClient = Any
+    S3NativeBucket = Any
+except (ImportError, ModuleNotFoundError):
+    raise ImportError(
+        """You are using the S3 functionality of Pathy without
+    having the required dependencies installed.
+
+    Please try installing them:
+
+        pip install pathy[s3]
+
+    """
+    )
+
+from . import (
+    Blob,
+    Bucket,
+    BucketClient,
+    BucketEntry,
+    PathyScanDir,
+    PurePathy,
+    register_client,
+)
+
+
+class BucketEntryS3(BucketEntry):
+    bucket: "BucketS3"
+    raw: Any
+
+
+@dataclass
+class BlobS3(Blob):
+    client: S3NativeClient
+    bucket: "BucketS3"
+
+    def delete(self) -> None:
+        self.client.delete_object(Bucket=self.bucket.name, Key=self.name)
+
+    def exists(self) -> bool:
+        response = self.client.list_objects_v2(
+            Bucket=self.bucket.name, Prefix=self.name
+        )
+        for obj in response.get("Contents", []):
+            if obj["Key"] == self.name:
+                return True
+        return False
+
+
+@dataclass
+class BucketS3(Bucket):
+    name: str
+    client: S3NativeClient
+    bucket: S3NativeBucket
+
+    def get_blob(self, blob_name: str) -> Optional[BlobS3]:
+        blob_stat: Dict[str, Any]
+        try:
+            blob_stat = self.client.head_object(Bucket=self.name, Key=blob_name)
+        except ClientError:
+            return None
+        updated = blob_stat["LastModified"].timestamp()
+        size = blob_stat["ContentLength"]
+        return BlobS3(
+            client=self.client,
+            bucket=self,
+            owner=None,  # type:ignore
+            name=blob_name,  # type:ignore
+            raw=None,
+            size=size,
+            updated=int(updated),  # type:ignore
+        )
+
+    def copy_blob(  # type:ignore[override]
+        self, blob: BlobS3, target: "BucketS3", name: str
+    ) -> Optional[BlobS3]:
+        source = {"Bucket": blob.bucket.name, "Key": blob.name}
+        self.client.copy(source, target.name, name)
+        pathy_blob: Optional[BlobS3] = self.get_blob(name)
+        assert pathy_blob is not None, "copy failed"
+        assert pathy_blob.updated is not None, "new blobl has invalid updated time"
+        return BlobS3(
+            client=self.client,
+            bucket=self.bucket,
+            owner=None,
+            name=name,
+            raw=pathy_blob,
+            size=pathy_blob.size,
+            updated=pathy_blob.updated,
+        )
+
+    def delete_blob(self, blob: BlobS3) -> None:  # type:ignore[override]
+        self.client.delete_object(Bucket=self.name, Key=blob.name)
+
+    def delete_blobs(self, blobs: List[BlobS3]) -> None:  # type:ignore[override]
+        for blob in blobs:
+            self.delete_blob(blob)
+
+    def exists(self) -> bool:
+        # TODO: ensure this always holds.
+        #
+        # S3 buckets don't make it this far if they don't exist. The BucketS3 instance
+        # is not instantiated unless a metadata check on the bucket passes.
+        return True
+
+
+class BucketClientS3(BucketClient):
+    client: S3NativeClient
+
+    @property
+    def client_params(self) -> Any:
+        return dict(client=self.client)
+
+    def __init__(self, **kwargs: Any) -> None:
+        self.recreate(**kwargs)
+
+    def recreate(self, **kwargs: Any) -> None:
+        creds = kwargs["credentials"] if "credentials" in kwargs else None
+        if creds is not None:
+            kwargs["project"] = creds.project_id
+        self.client = boto3.client("s3")  # type:ignore
+
+    def make_uri(self, path: PurePathy) -> str:
+        return str(path)
+
+    def create_bucket(  # type:ignore[override]
+        self, path: PurePathy
+    ) -> S3NativeBucket:
+        return self.client.create_bucket(Bucket=path.root)  # type:ignore
+
+    def delete_bucket(self, path: PurePathy) -> None:
+        self.client.delete_bucket(Bucket=path.root)
+
+    def exists(self, path: PurePathy) -> bool:
+        # Because we want all the parents of a valid blob (e.g. "directory" in
+        # "directory/foo.file") to return True, we enumerate the blobs with a prefix
+        # and compare the object names to see if they match a substring of the path
+        key_name = str(path.key)
+        for obj in self.list_blobs(path):
+            if obj.name.startswith(key_name + path._flavour.sep):  # type:ignore
+                return True
+        return False
+
+    def lookup_bucket(self, path: PurePathy) -> Optional[BucketS3]:
+        try:
+            return self.get_bucket(path)
+        except FileNotFoundError:
+            return None
+
+    def get_bucket(self, path: PurePathy) -> BucketS3:
+        try:
+            native_bucket = self.client.head_bucket(Bucket=path.root)
+            return BucketS3(str(path.root), client=self.client, bucket=native_bucket)
+        except (ClientError, ParamValidationError):
+            raise FileNotFoundError(f"Bucket {path.root} does not exist!")
+
+    def list_buckets(  # type:ignore[override]
+        self, **kwargs: Dict[str, Any]
+    ) -> Generator[S3NativeBucket, None, None]:
+        return self.client.list_buckets(**kwargs)  # type:ignore
+
+    def scandir(  # type:ignore[override]
+        self,
+        path: Optional[PurePathy] = None,
+        prefix: Optional[str] = None,
+        delimiter: Optional[str] = None,
+    ) -> PathyScanDir:
+        return ScanDirS3(client=self, path=path, prefix=prefix, delimiter=delimiter)
+
+    def list_blobs(
+        self,
+        path: PurePathy,
+        prefix: Optional[str] = None,
+        delimiter: Optional[str] = None,
+    ) -> Generator[BlobS3, None, None]:
+        bucket = self.lookup_bucket(path)
+        if bucket is None:
+            return
+        paginator = self.client.get_paginator("list_objects_v2")
+        kwargs = {"Bucket": bucket.name}
+        if prefix is not None:
+            kwargs["Prefix"] = prefix
+        for page in paginator.paginate(**kwargs):
+            for item in page.get("Contents", []):
+                yield BlobS3(
+                    client=self.client,
+                    bucket=bucket,
+                    owner=None,
+                    name=item["Key"],
+                    raw=item,
+                    size=item["Size"],
+                    updated=int(item["LastModified"].timestamp()),
+                )
+
+
+class ScanDirS3(PathyScanDir):
+    _client: BucketClientS3
+
+    def scandir(self) -> Generator[BucketEntryS3, None, None]:
+        if self._path is None or not self._path.root:
+            gcs_bucket: S3NativeBucket
+            for gcs_bucket in self._client.list_buckets():
+                yield BucketEntryS3(
+                    gcs_bucket.name, is_dir=True, raw=None  # type:ignore
+                )
+            return
+        sep = self._path._flavour.sep  # type:ignore
+        bucket = self._client.lookup_bucket(self._path)
+        if bucket is None:
+            return
+
+        kwargs: Any = {"Bucket": bucket.name, "Delimiter": sep}
+        if self._prefix is not None:
+            kwargs["Prefix"] = self._prefix
+        continuation_token: Optional[str] = None
+        while True:
+            if continuation_token:
+                kwargs["ContinuationToken"] = continuation_token
+            response = self._client.client.list_objects_v2(**kwargs)
+            for folder in response.get("CommonPrefixes", []):
+                prefix = folder["Prefix"]
+                full_name = prefix[:-1] if prefix.endswith(sep) else prefix
+                name = full_name.split(sep)[-1]
+                yield BucketEntryS3(name, is_dir=True)
+            for file in response.get("Contents", ()):
+                name = file["Key"].split(sep)[-1]
+                yield BucketEntryS3(
+                    name=name,
+                    is_dir=False,
+                    size=file["Size"],
+                    last_modified=int(file["LastModified"].timestamp()),
+                )
+            if not response.get("IsTruncated"):
+                break
+            continuation_token = response.get("NextContinuationToken")
+
+
+register_client("s3", BucketClientS3)

--- a/pathy/s3.py
+++ b/pathy/s3.py
@@ -124,14 +124,13 @@ class BucketClientS3(BucketClient):
     def recreate(self, **kwargs: Any) -> None:
         key_id = kwargs.get("key_id", None)
         key_secret = kwargs.get("key_secret", None)
+        boto_session: Any = boto3
         if key_id is not None and key_secret is not None:
-            self._session = boto3.Session(  # type:ignore
+            self._session = boto_session = boto3.Session(  # type:ignore
                 aws_access_key_id=key_id,
                 aws_secret_access_key=key_secret,
             )
-            self.client = self._session.client("s3")  # type:ignore
-        else:
-            self.client = boto3.client("s3")  # type:ignore
+        self.client = boto_session.client("s3")  # type:ignore
 
     def make_uri(self, path: PurePathy) -> str:
         return str(path)

--- a/pathy/s3.py
+++ b/pathy/s3.py
@@ -121,7 +121,16 @@ class BucketClientS3(BucketClient):
         self.recreate(**kwargs)
 
     def recreate(self, **kwargs: Any) -> None:
-        self.client = boto3.client("s3")  # type:ignore
+        key_id = kwargs.get("key_id", None)
+        key_secret = kwargs.get("key_secret", None)
+        if key_id is not None and key_secret is not None:
+            session = boto3.Session(
+                aws_access_key_id=key_id,
+                aws_secret_access_key=key_secret,
+            )
+        else:
+            session = boto3
+        self.client = session.client("s3")  # type:ignore
 
     def make_uri(self, path: PurePathy) -> str:
         return str(path)

--- a/pathy/s3.py
+++ b/pathy/s3.py
@@ -123,8 +123,9 @@ class BucketClientS3(BucketClient):
     def recreate(self, **kwargs: Any) -> None:
         key_id = kwargs.get("key_id", None)
         key_secret = kwargs.get("key_secret", None)
+        session: Any
         if key_id is not None and key_secret is not None:
-            session = boto3.Session(
+            session = boto3.Session(  # type:ignore
                 aws_access_key_id=key_id,
                 aws_secret_access_key=key_secret,
             )

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ def setup_package():
         long_description = f.read()
     extras = {
         "gcs": ["google-cloud-storage>=1.26.0,<2.0.0"],
+        "s3": ["boto3"],
         "test": ["pytest", "pytest-coverage", "mock", "typer-cli"],
     }
     extras["all"] = [item for group in extras.values() for item in group]


### PR DESCRIPTION
Add support for S3 bucket access. To use, install the `s3` package extras:

```bash
pip install pathy[s3]
```

Then you can use s3 paths similarly to gs ones:
```python
from pathy import Pathy

a = Pathy("s3://pathy-tests-bucket/myfile.txt")
a.touch()
a.write_text("Hello World!")
assert a.read_text() == "Hello World!"
```

If you install the gcs extras too, you can do neat things like copy files from one service to another:
```bash
pip install "pathy[s3,gcs]"
pathy cp gs://bucket/copy.zip s3://bucket/file.zip
```

**Changes**
- Update tests to change schemes based on the adapter being tested
- Add s3 client adapter / tests
- Add cloud platform support table to readme
