### PR TITLE
feat(cli): add version number to cli help string

### DIFF
--- a/README.md
+++ b/README.md
@@ -412,7 +412,7 @@ client library prefers.
 
 # CLI
 
-Pathy command line interface.
+Pathy command line interface. (v0.5.1)
 
 **Usage**:
 

--- a/pathy/cli.py
+++ b/pathy/cli.py
@@ -5,8 +5,9 @@ from typing import List, Union
 import typer
 
 from . import BasePath, FluidPath, Pathy
+from .about import __version__
 
-app: typer.Typer = typer.Typer(help="Pathy command line interface.")
+app: typer.Typer = typer.Typer(help=f"Pathy command line interface. (v{__version__})")
 
 
 @app.command()


### PR DESCRIPTION
Add the version number to the CLI app's help string so that it's easy to check the installed version:

```bash
(.env) √ pathy % pathy
Usage: pathy [OPTIONS] COMMAND [ARGS]...

  Pathy command line interface. (v0.5.1)

Options:
  --install-completion  Install completion for the current shell.
  --show-completion     Show completion for the current shell, to copy it or
                        customize the installation.

  --help                Show this message and exit.

Commands:
  cp  Copy a blob or folder of blobs from one bucket to another.
  ls  List the blobs that exist at a given location.
  mv  Move a blob or folder of blobs from one path to another.
  rm  Remove a blob or folder of blobs from a given location.
```