### PR TITLE
chore: add mock/dataclass type stubs

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -13,3 +13,7 @@ typer-cli
 # test serializing spacy models using Pathy in place of Path
 https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-2.2.5/en_core_web_sm-2.2.5.tar.gz#egg=en_core_web_sm
 spacy
+
+# Mypy type stubs
+types-mock
+types-dataclasses


### PR DESCRIPTION
Fixes the CI build's lint step.