### PR TITLE
feat: support smart_open >=5.0.0,<6.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -412,7 +412,7 @@ client library prefers.
 
 # CLI
 
-Pathy command line interface. (v0.5.1)
+Pathy command line interface. (v0.5.2)
 
 **Usage**:
 

--- a/pathy/s3.py
+++ b/pathy/s3.py
@@ -112,11 +112,14 @@ class BucketS3(Bucket):
 
 class BucketClientS3(BucketClient):
     client: S3NativeClient
-    _session: Optional[Any]
+    _session: Optional[boto3.Session]
 
     @property
     def client_params(self) -> Dict[str, Any]:
-        return dict() if self._session is None else dict(session=self._session)
+        if self._session is None:
+            return dict()
+        session: Any = self._session
+        return dict(client=session.client("s3"))
 
     def __init__(self, **kwargs: Any) -> None:
         self.recreate(**kwargs)

--- a/pathy/s3.py
+++ b/pathy/s3.py
@@ -116,10 +116,9 @@ class BucketClientS3(BucketClient):
 
     @property
     def client_params(self) -> Dict[str, Any]:
-        if self._session is None:
-            return dict()
         session: Any = self._session
-        return dict(client=session.client("s3"))
+        result: Any = dict() if session is None else dict(client=session.client("s3"))
+        return result
 
     def __init__(self, **kwargs: Any) -> None:
         self.recreate(**kwargs)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-smart-open>=2.2.0,<4.0.0
+smart-open>=2.2.0,<6.0.0
 typer>=0.3.0,<1.0.0
 dataclasses>=0.6,<1.0; python_version < "3.7"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-smart-open>=2.2.0,<6.0.0
+smart-open>=5.0.0,<6.0.0
 typer>=0.3.0,<1.0.0
 dataclasses>=0.6,<1.0; python_version < "3.7"


### PR DESCRIPTION
The smart_open API for specifying s3 bucket credentials changed in v5.0.0.

Fixes #61 