### PR TITLE
Support for smart-open >= 6.0.0

### DIFF
--- a/pathy/__init__.py
+++ b/pathy/__init__.py
@@ -167,7 +167,7 @@ class BucketClient:
             newline=newline,
             transport_params=client_params,
             # Disable de/compression based on the file extension
-            ignore_ext=True,
+            compression="disable",
         )  # type:ignore
 
     def make_uri(self, path: "Pathy") -> str:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-smart-open>=5.0.0,<6.0.0
+smart-open>=6.0.0,<7.0.0
 typer>=0.3.0,<1.0.0
 dataclasses>=0.6,<1.0; python_version < "3.7"


### PR DESCRIPTION
 `ignore_ext` was changed in [6.0.0](https://github.com/RaRe-Technologies/smart_open/releases/tag/v6.0.0) to `compression`.