### PR TITLE
chore: restore old typer range

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 smart-open>=5.2.1,<6.0.0
-typer>=0.3.0,<0.4.0
+typer>=0.3.0,<1.0.0
 dataclasses>=0.6,<1.0; python_version < "3.7"


### PR DESCRIPTION
I changed this hastily trying to satisfy the pip constraint resolver. The old range was fine, and the new one actually excludes newer typer versions.