### PR TITLE
Switch from deprecated `ignore_ext` on `compression`

### DIFF
--- a/pathy/__init__.py
+++ b/pathy/__init__.py
@@ -29,6 +29,7 @@ from typing import (
 )
 
 import smart_open
+import smart_open.compression
 
 SUBCLASS_ERROR = "must be implemented in a subclass"
 
@@ -167,7 +168,7 @@ class BucketClient:
             newline=newline,
             transport_params=client_params,
             # Disable de/compression based on the file extension
-            ignore_ext=True,
+            compression=smart_open.compression.NO_COMPRESSION,
         )  # type:ignore
 
     def make_uri(self, path: "Pathy") -> str:


### PR DESCRIPTION
Also this fix works `pathy` with `smart-open` 6.0.0