### PR TITLE
Add python 3.11 support: Remove use of pathlib._Accessor

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8, 3.9, 3.10, 3.11]
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/pathy/__init__.py
+++ b/pathy/__init__.py
@@ -7,7 +7,6 @@ import uuid
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from io import DEFAULT_BUFFER_SIZE
-from pathlib import _Accessor  # type:ignore
 from pathlib import _PosixFlavour  # type:ignore
 from pathlib import _WindowsFlavour  # type:ignore
 from pathlib import Path, PurePath
@@ -336,7 +335,7 @@ class BasePath(_PathyExtensions, Path):
     _flavour = _windows_flavour if os.name == "nt" else _posix_flavour  # type:ignore
 
 
-class BucketsAccessor(_Accessor):  # type:ignore
+class BucketsAccessor:
     """Access data from blob buckets"""
 
     _client: Optional[BucketClient]

--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,8 @@ def setup_package():
             "Programming Language :: Python :: 3.7",
             "Programming Language :: Python :: 3.8",
             "Programming Language :: Python :: 3.9",
+            "Programming Language :: Python :: 3.10",
+            "Programming Language :: Python :: 3.11",
         ],
     )
 


### PR DESCRIPTION
Changes

- Remove use of `pathlib._Accessor`.
- Add python 3.10 and 3.11 tests to CI.


Python 3.11 has removed a non-public method `pathlib._Accessor`: https://github.com/python/cpython/pull/25701. 

Accessor-style classes in pathlib are discouraged, but a simple fix here to make pathy work is to simply remove the deprecated superclass `_Accessor`.

