### PR TITLE
Feat/python311

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8, 3.9, 3.10, 3.11]
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9, 3.10.8, 3.11]
+        python-version: [3.6, 3.7, 3.8, 3.9, 3.10.6, 3.11]
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9, 3.10, 3.11]
+        python-version: [3.6, 3.7, 3.8, 3.9, 3.10.8, 3.11]
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ ENV/
 env.bak/
 venv.bak/
 env3.7/
+.py311env
 
 # mypy
 .mypy_cache/

--- a/pathy/__init__.py
+++ b/pathy/__init__.py
@@ -380,7 +380,9 @@ class Pathy(Path, PurePathy):
         return super().__truediv__(key)  # type:ignore
 
     def _init(self: "Pathy", template: Optional[Any] = None) -> None:
-        super()._init(template=template)  # type:ignore
+        # This was removed in python 3.10, and in earlier versions we
+        # assign the _accessor directly, so pass on the super() behavior
+        pass
 
     @classmethod
     def fluid(cls, path_candidate: Union[str, FluidPath]) -> FluidPath:

--- a/pathy/__init__.py
+++ b/pathy/__init__.py
@@ -366,10 +366,8 @@ class BucketsAccessor:
 class Pathy(Path, PurePathy):
     """Subclass of `pathlib.Path` that works with bucket APIs."""
 
-    if sys.version_info.major == 3 and sys.version_info.minor < 11:
-        _accessor: BucketsAccessor = BucketsAccessor()
-
     __slots__ = ()
+    _accessor: BucketsAccessor = BucketsAccessor()
     _NOT_SUPPORTED_MESSAGE = "{method} is an unsupported bucket operation"
     _client: Optional[BucketClient]
 

--- a/pathy/__init__.py
+++ b/pathy/__init__.py
@@ -507,8 +507,6 @@ class Pathy(Path, PurePathy):
         """Returns True if the path points to an existing bucket, blob, or prefix."""
         self._absolute_path_validation()
         client = self.client(self)
-        if not self.root:
-            return any(client.list_buckets())
         bucket = client.lookup_bucket(self)
         if bucket is None or not bucket.exists():
             return False

--- a/pathy/__init__.py
+++ b/pathy/__init__.py
@@ -2,7 +2,6 @@ import importlib
 import os
 import pathlib
 import shutil
-import sys
 import tempfile
 import uuid
 from abc import ABC, abstractmethod

--- a/pathy/__init__.py
+++ b/pathy/__init__.py
@@ -376,7 +376,9 @@ class Pathy(Path, PurePathy):
     def client(self, path: "Pathy") -> BucketClient:
         return get_client(path.scheme)
 
-    def __truediv__(self, key: Union[str, Path, "Pathy", PurePathy]) -> "Pathy":  # type: ignore[override]
+    def __truediv__(  # type: ignore[override]
+        self, key: Union[str, Path, "Pathy", PurePathy]
+    ) -> "Pathy":
         return super().__truediv__(key)  # type:ignore
 
     def _init(self: "Pathy", template: Optional[Any] = None) -> None:
@@ -499,7 +501,9 @@ class Pathy(Path, PurePathy):
                 updated = int(round(stat.st_mtime))
                 yield BlobStat(name=os_blob.name, size=file_size, last_modified=updated)
 
-    def stat(self: "Pathy", *, follow_symlinks: bool = True) -> BlobStat:  # type: ignore[override]
+    def stat(  # type: ignore[override]
+        self: "Pathy", *, follow_symlinks: bool = True
+    ) -> BlobStat:
         """Returns information about this bucket path."""
         self._absolute_path_validation()
         if not self.key:
@@ -732,7 +736,7 @@ class Pathy(Path, PurePathy):
         Raises FileExistsError if exist_ok is false and the bucket already exists.
         """
         try:
-            # If the whole path is just the bucket, respect the result of "bucket.exists()"
+            # If the path is just the bucket, respect the result of "bucket.exists()"
             if self.key is None and not exist_ok and self.bucket.exists():
                 raise FileExistsError("Bucket {} already exists".format(self.bucket))
             return self.client(self).mkdir(self, mode)

--- a/pathy/__init__.py
+++ b/pathy/__init__.py
@@ -343,7 +343,7 @@ class BasePath(Path):
     _flavour = _windows_flavour if os.name == "nt" else _posix_flavour  # type:ignore
 
     def ls(self: Any) -> Generator["BlobStat", None, None]:
-        client: BucketClientFS = get_client("fs")
+        client: BucketClient = get_client(getattr(self, "scheme", "file"))
         blobs: "ScanDirFS" = cast(
             ScanDirFS, client.scandir(self, prefix=getattr(self, "prefix", None))
         )  # type:ignore
@@ -358,7 +358,7 @@ class BucketsAccessor:
     """Path access for python < 3.11"""
 
     def scandir(self, target: Any) -> "PathyScanDir":
-        client: BucketClientFS = get_client("fs")
+        client: BucketClientFS = get_client(getattr(target, "scheme", "file"))
         return client.scandir(target, prefix=getattr(target, "prefix", None))
 
 

--- a/pathy/_tests/__init__.py
+++ b/pathy/_tests/__init__.py
@@ -1,15 +1,25 @@
-has_gcs: bool
+import os
+
+gcs_testable: bool
+gcs_installed: bool
+
+
 try:
     from ..gcs import BucketClientGCS
 
-    has_gcs = bool(BucketClientGCS)
+    gcs_installed = bool(BucketClientGCS)
+    gcs_testable = gcs_installed and "GCS_CREDENTIALS" in os.environ
 except ImportError:
-    has_gcs = False
+    gcs_installed = False
+    gcs_testable = False
 
-has_s3: bool
+s3_testable: bool
+s3_installed: bool
 try:
     from ..s3 import BucketClientS3
 
-    has_s3 = bool(BucketClientS3)
+    s3_installed = bool(BucketClientS3)
+    s3_testable = s3_installed and "PATHY_S3_ACCESS_ID" in os.environ
 except ImportError:
-    has_s3 = False
+    s3_installed = False
+    s3_testable = False

--- a/pathy/_tests/conftest.py
+++ b/pathy/_tests/conftest.py
@@ -10,12 +10,18 @@ import pytest
 
 from pathy import Pathy, set_client_params, use_fs, use_fs_cache
 
-from . import has_gcs
+from . import has_gcs, has_s3
 
-has_credentials = "GCS_CREDENTIALS" in os.environ
+has_gcs_credentials = "GCS_CREDENTIALS" in os.environ
+has_s3_credentials = "PATHY_S3_ACCESS_ID" in os.environ
 
 # Which adapters to use
-TEST_ADAPTERS = ["gcs", "s3", "fs"] if has_credentials and has_gcs else ["fs"]
+TEST_ADAPTERS = ["fs"]
+if has_gcs_credentials and has_gcs:
+    TEST_ADAPTERS.append("gcs")
+if has_s3_credentials and has_s3:
+    TEST_ADAPTERS.append("s3")
+
 # A unique identifier used to allow each python version and OS to test
 # with separate bucket paths. This makes it possible to parallelize the
 # tests.
@@ -84,7 +90,7 @@ def gcs_credentials_from_env() -> Optional[Any]:
 
 def s3_credentials_from_env() -> Optional[Tuple[str, str]]:
     """Extract an access key ID and Secret from the environment."""
-    if not has_gcs:
+    if not has_s3:
         return None
 
     access_key_id: Optional[str] = os.environ.get("PATHY_S3_ACCESS_ID", None)

--- a/pathy/_tests/conftest.py
+++ b/pathy/_tests/conftest.py
@@ -10,16 +10,13 @@ import pytest
 
 from pathy import Pathy, set_client_params, use_fs, use_fs_cache
 
-from . import has_gcs, has_s3
-
-has_gcs_credentials = "GCS_CREDENTIALS" in os.environ
-has_s3_credentials = "PATHY_S3_ACCESS_ID" in os.environ
+from . import gcs_testable, s3_testable
 
 # Which adapters to use
 TEST_ADAPTERS = ["fs"]
-if has_gcs_credentials and has_gcs:
+if gcs_testable:
     TEST_ADAPTERS.append("gcs")
-if has_s3_credentials and has_s3:
+if s3_testable:
     TEST_ADAPTERS.append("s3")
 
 # A unique identifier used to allow each python version and OS to test
@@ -60,7 +57,7 @@ def gcs_credentials_from_env() -> Optional[Any]:
 
     Raises AssertionError if the value is present but does not point to a file
     or valid JSON content."""
-    if not has_gcs:
+    if not gcs_testable:
         return None
 
     creds = os.environ.get("GCS_CREDENTIALS", None)
@@ -90,7 +87,7 @@ def gcs_credentials_from_env() -> Optional[Any]:
 
 def s3_credentials_from_env() -> Optional[Tuple[str, str]]:
     """Extract an access key ID and Secret from the environment."""
-    if not has_s3:
+    if not s3_testable:
         return None
 
     access_key_id: Optional[str] = os.environ.get("PATHY_S3_ACCESS_ID", None)

--- a/pathy/_tests/test_base.py
+++ b/pathy/_tests/test_base.py
@@ -146,8 +146,6 @@ def test_client_base_bucket_raises_not_implemented() -> None:
     with pytest.raises(NotImplementedError):
         bucket.copy_blob(blob, bucket, "baz")
     with pytest.raises(NotImplementedError):
-        bucket.get_blob("baz")
-    with pytest.raises(NotImplementedError):
         bucket.delete_blobs([blob])
     with pytest.raises(NotImplementedError):
         bucket.delete_blob(blob)
@@ -170,8 +168,6 @@ def test_client_base_bucket_client_raises_not_implemented() -> None:
     with pytest.raises(NotImplementedError):
         client.is_dir(Pathy("gs://foo"))
     with pytest.raises(NotImplementedError):
-        client.lookup_bucket(Pathy("gs://foo"))
-    with pytest.raises(NotImplementedError):
         client.get_bucket(Pathy("gs://foo"))
     with pytest.raises(NotImplementedError):
         client.list_buckets()
@@ -188,6 +184,11 @@ def test_client_base_bucket_client_raises_not_implemented() -> None:
 def test_bucket_client_rmdir() -> None:
     client: BucketClient = BucketClient()
     client.rmdir(Pathy("gs://foo/bar"))
+
+
+def test_bucket_client_get_blob() -> None:
+    client: BucketClient = BucketClient()
+    assert client.get_blob(Pathy("gs://foo")) is None
 
 
 def test_bucket_client_make_uri() -> None:

--- a/pathy/_tests/test_base.py
+++ b/pathy/_tests/test_base.py
@@ -146,6 +146,8 @@ def test_client_base_bucket_raises_not_implemented() -> None:
     with pytest.raises(NotImplementedError):
         bucket.copy_blob(blob, bucket, "baz")
     with pytest.raises(NotImplementedError):
+        bucket.get_blob("baz")
+    with pytest.raises(NotImplementedError):
         bucket.delete_blobs([blob])
     with pytest.raises(NotImplementedError):
         bucket.delete_blob(blob)

--- a/pathy/_tests/test_base.py
+++ b/pathy/_tests/test_base.py
@@ -10,7 +10,6 @@ from .. import (
     BucketClient,
     BucketClientFS,
     BucketEntry,
-    BucketsAccessor,
     ClientError,
     Pathy,
     PurePathy,
@@ -121,39 +120,16 @@ def test_path_truediv_operator_overload_with_subclass() -> None:
     assert isinstance(other_pathy, Pathy)
 
 
-def test_buckets_accessor_get_blob(temp_folder: Path) -> None:
-    accessor = BucketsAccessor()
-    use_fs(temp_folder)
-    # no scheme/bucket prefix
-    assert accessor.get_blob(Pathy("foo")) is None
-    # a valid bucket that does not exist
-    assert accessor.get_blob(Pathy("gs://invalid_bucket_134515h15h15j1h")) is None
-
-
-def test_buckets_accessor_rename_replace(temp_folder: Path) -> None:
+def test_buckets_rename_replace(temp_folder: Path) -> None:
     use_fs(temp_folder)
     Pathy.from_bucket("foo").mkdir()
-    accessor = Pathy("")._accessor  # type:ignore
     from_path = Pathy("gs://foo/bar")
     to_path = Pathy("gs://foo/baz")
     # Source foo/bar does not exist
     with pytest.raises(FileNotFoundError):
-        accessor.rename(from_path, to_path)
+        from_path.rename(to_path)
     with pytest.raises(FileNotFoundError):
-        accessor.replace(from_path, to_path)
-
-
-def test_buckets_accessor_exists(temp_folder: Path) -> None:
-    accessor = BucketsAccessor()
-    use_fs(temp_folder)
-    # enumerates buckets, but there are none
-    assert accessor.exists(Pathy("")) is False
-
-    # Create a bucket
-    Pathy("gs://bucket_name").mkdir()
-
-    # There is a bucket, so now exists returns true
-    assert accessor.exists(Pathy("")) is True
+        from_path.replace(to_path)
 
 
 def test_client_create_bucket(temp_folder: Path) -> None:

--- a/pathy/_tests/test_cli.py
+++ b/pathy/_tests/test_cli.py
@@ -11,8 +11,8 @@ from .conftest import ENV_ID, TEST_ADAPTERS
 
 runner = CliRunner()
 
-# TODO: add support/test for wildcard cp/mv/rm/ls paths (e.g. "pathy cp gs://my-bucket/*.file ./")
-# TODO: add support/test for streaming in/out sources (e.g. "pathy cp - gs://my-bucket/my.file")
+# TODO: add support for wildcard cp/mv/rm/ls paths (e.g. "pathy cp gs://my/*.file ./")
+# TODO: add support for streaming in/out sources (e.g. "pathy cp - gs://my/my.file")
 
 
 @pytest.mark.parametrize("adapter", TEST_ADAPTERS)

--- a/pathy/_tests/test_clients.py
+++ b/pathy/_tests/test_clients.py
@@ -16,11 +16,11 @@ from pathy import (
     use_fs_cache,
 )
 
-from . import has_gcs
+from . import gcs_testable
 from .conftest import ENV_ID, TEST_ADAPTERS
 
 
-@pytest.mark.skipif(not has_gcs, reason="requires gcs")
+@pytest.mark.skipif(not gcs_testable, reason="requires gcs")
 def test_clients_get_client_works_with_optional_builtin_schems() -> None:
     from pathy.gcs import BucketClientGCS
 

--- a/pathy/_tests/test_file.py
+++ b/pathy/_tests/test_file.py
@@ -117,6 +117,6 @@ def test_file_scandir_list_buckets(
     with_adapter: str, bucket: str, other_bucket: str
 ) -> None:
     root = Pathy()
-    client = root._accessor.client(root)  # type:ignore
+    client = root.client(root)
     scandir = ScanDirFS(client=client, path=root)
     assert sorted([s.name for s in scandir]) == sorted([bucket, other_bucket])

--- a/pathy/_tests/test_gcs.py
+++ b/pathy/_tests/test_gcs.py
@@ -51,7 +51,7 @@ def test_gcs_scandir_list_buckets(
     from pathy.gcs import ScanDirGCS
 
     root = Pathy("gs://foo/bar")
-    client = root._accessor.client(root)  # type:ignore
+    client = root.client(root)
     scandir = ScanDirGCS(client=client, path=Pathy())
     assert sorted([s.name for s in scandir]) == sorted([bucket, other_bucket])
 
@@ -62,7 +62,7 @@ def test_gcs_scandir_invalid_bucket_name(with_adapter: str) -> None:
     from pathy.gcs import ScanDirGCS
 
     root = Pathy("gs://invalid_h3gE_ds5daEf_Sdf15487t2n4/bar")
-    client = root._accessor.client(root)  # type:ignore
+    client = root.client(root)
     scandir = ScanDirGCS(client=client, path=root)
     assert len(list(scandir)) == 0
 

--- a/pathy/_tests/test_gcs.py
+++ b/pathy/_tests/test_gcs.py
@@ -36,7 +36,7 @@ def test_gcs_as_uri(with_adapter: str, bucket: str) -> None:
     assert Pathy("gs://bucket/key").as_uri() == "gs://bucket/key"
 
 
-@pytest.mark.skipif(not gcs_installed, reason="requires gcs deps to NOT be installed")
+@pytest.mark.skipif(gcs_installed, reason="requires gcs deps to NOT be installed")
 def test_gcs_import_error_missing_deps() -> None:
     use_fs(False)
     with pytest.raises(ImportError):

--- a/pathy/_tests/test_gcs.py
+++ b/pathy/_tests/test_gcs.py
@@ -4,7 +4,7 @@ import pytest
 
 from pathy import Pathy, get_client, set_client_params, use_fs
 
-from . import has_gcs
+from . import gcs_installed, gcs_testable
 
 GCS_ADAPTER = ["gcs"]
 
@@ -17,7 +17,7 @@ def raise_default_creds_error() -> None:
 
 @pytest.mark.parametrize("adapter", GCS_ADAPTER)
 @patch("google.auth.default", raise_default_creds_error)
-@pytest.mark.skipif(not has_gcs, reason="requires gcs")
+@pytest.mark.skipif(not gcs_testable, reason="requires gcs")
 def test_gcs_default_credentials_error_is_preserved(
     with_adapter: str, bucket: str
 ) -> None:
@@ -29,14 +29,14 @@ def test_gcs_default_credentials_error_is_preserved(
 
 
 @pytest.mark.parametrize("adapter", GCS_ADAPTER)
-@pytest.mark.skipif(not has_gcs, reason="requires gcs")
+@pytest.mark.skipif(not gcs_testable, reason="requires gcs")
 def test_gcs_as_uri(with_adapter: str, bucket: str) -> None:
     assert Pathy("gs://etc/passwd").as_uri() == "gs://etc/passwd"
     assert Pathy("gs://etc/init.d/apache2").as_uri() == "gs://etc/init.d/apache2"
     assert Pathy("gs://bucket/key").as_uri() == "gs://bucket/key"
 
 
-@pytest.mark.skipif(has_gcs, reason="requires gcs deps to NOT be installed")
+@pytest.mark.skipif(not gcs_installed, reason="requires gcs deps to NOT be installed")
 def test_gcs_import_error_missing_deps() -> None:
     use_fs(False)
     with pytest.raises(ImportError):
@@ -44,7 +44,7 @@ def test_gcs_import_error_missing_deps() -> None:
 
 
 @pytest.mark.parametrize("adapter", GCS_ADAPTER)
-@pytest.mark.skipif(not has_gcs, reason="requires gcs")
+@pytest.mark.skipif(not gcs_testable, reason="requires gcs")
 def test_gcs_scandir_list_buckets(
     with_adapter: str, bucket: str, other_bucket: str
 ) -> None:
@@ -57,7 +57,7 @@ def test_gcs_scandir_list_buckets(
 
 
 @pytest.mark.parametrize("adapter", GCS_ADAPTER)
-@pytest.mark.skipif(not has_gcs, reason="requires gcs")
+@pytest.mark.skipif(not gcs_testable, reason="requires gcs")
 def test_gcs_scandir_invalid_bucket_name(with_adapter: str) -> None:
     from pathy.gcs import ScanDirGCS
 
@@ -68,7 +68,7 @@ def test_gcs_scandir_invalid_bucket_name(with_adapter: str) -> None:
 
 
 @pytest.mark.parametrize("adapter", GCS_ADAPTER)
-@pytest.mark.skipif(not has_gcs, reason="requires gcs")
+@pytest.mark.skipif(not gcs_testable, reason="requires gcs")
 def test_gcs_bucket_client_list_blobs(with_adapter: str, bucket: str) -> None:
     """Test corner-case in GCS client that isn't easily reachable from Pathy"""
     from pathy.gcs import BucketClientGCS

--- a/pathy/_tests/test_pathy.py
+++ b/pathy/_tests/test_pathy.py
@@ -271,7 +271,7 @@ def test_pathy_open_binary_read(with_adapter: str, bucket: str) -> None:
 
 @pytest.mark.parametrize("adapter", TEST_ADAPTERS)
 def test_pathy_readwrite_text(with_adapter: str, bucket: str) -> None:
-    path = Pathy(f"s3://{bucket}/{ENV_ID}/write_text/file.txt")
+    path = Pathy(f"{with_adapter}://{bucket}/{ENV_ID}/write_text/file.txt")
     path.write_text("---")
     with path.open() as file_obj:
         assert file_obj.read() == "---"

--- a/pathy/_tests/test_pathy.py
+++ b/pathy/_tests/test_pathy.py
@@ -14,7 +14,6 @@ from .. import (
     BasePath,
     BlobStat,
     BucketClientFS,
-    BucketsAccessor,
     FluidPath,
     Pathy,
     clear_fs_cache,
@@ -565,13 +564,12 @@ def test_pathy_ignore_extension(with_adapter: str, bucket: str) -> None:
 def test_pathy_raises_with_no_known_bucket_clients_for_a_scheme(
     temp_folder: Path,
 ) -> None:
-    accessor = BucketsAccessor()
     path = Pathy("foo://foo")
     with pytest.raises(ValueError):
-        accessor.client(path)
+        path.client(path)
     # Setting a fallback FS adapter fixes the problem
     use_fs(str(temp_folder))
-    assert isinstance(accessor.client(path), BucketClientFS)
+    assert isinstance(path.client(path), BucketClientFS)
 
 
 @pytest.mark.skipif(not has_spacy, reason="requires spacy and en_core_web_sm model")

--- a/pathy/_tests/test_s3.py
+++ b/pathy/_tests/test_s3.py
@@ -2,14 +2,14 @@ import pytest
 
 from pathy import Pathy, get_client, use_fs
 
-from . import has_s3
+from . import s3_installed, s3_testable
 from .conftest import ENV_ID
 
 S3_ADAPTER = ["s3"]
 
 
 @pytest.mark.parametrize("adapter", S3_ADAPTER)
-@pytest.mark.skipif(not has_s3, reason="requires s3")
+@pytest.mark.skipif(not s3_testable, reason="requires s3")
 def test_s3_scandir_list_buckets(
     with_adapter: str, bucket: str, other_bucket: str
 ) -> None:
@@ -24,7 +24,7 @@ def test_s3_scandir_list_buckets(
 
 
 @pytest.mark.parametrize("adapter", S3_ADAPTER)
-@pytest.mark.skipif(not has_s3, reason="requires s3")
+@pytest.mark.skipif(not s3_testable, reason="requires s3")
 def test_s3_scandir_scandir_continuation_token(
     with_adapter: str, bucket: str, other_bucket: str
 ) -> None:
@@ -40,7 +40,7 @@ def test_s3_scandir_scandir_continuation_token(
 
 
 @pytest.mark.parametrize("adapter", S3_ADAPTER)
-@pytest.mark.skipif(not has_s3, reason="requires s3")
+@pytest.mark.skipif(not s3_testable, reason="requires s3")
 def test_s3_scandir_invalid_bucket_name(with_adapter: str) -> None:
     from pathy.s3 import ScanDirS3
 
@@ -51,7 +51,7 @@ def test_s3_scandir_invalid_bucket_name(with_adapter: str) -> None:
 
 
 @pytest.mark.parametrize("adapter", S3_ADAPTER)
-@pytest.mark.skipif(not has_s3, reason="requires s3")
+@pytest.mark.skipif(not s3_testable, reason="requires s3")
 def test_s3_bucket_client_list_blobs(with_adapter: str, bucket: str) -> None:
     """Test corner-case in S3 client that isn't easily reachable from Pathy"""
     from pathy.s3 import BucketClientS3
@@ -61,7 +61,7 @@ def test_s3_bucket_client_list_blobs(with_adapter: str, bucket: str) -> None:
     assert len(list(client.list_blobs(root))) == 0
 
 
-@pytest.mark.skipif(has_s3, reason="requires s3 deps to NOT be installed")
+@pytest.mark.skipif(not s3_installed, reason="requires s3 deps to NOT be installed")
 def test_s3_import_error_missing_deps() -> None:
     use_fs(False)
     with pytest.raises(ImportError):

--- a/pathy/_tests/test_s3.py
+++ b/pathy/_tests/test_s3.py
@@ -61,7 +61,7 @@ def test_s3_bucket_client_list_blobs(with_adapter: str, bucket: str) -> None:
     assert len(list(client.list_blobs(root))) == 0
 
 
-@pytest.mark.skipif(not s3_installed, reason="requires s3 deps to NOT be installed")
+@pytest.mark.skipif(s3_installed, reason="requires s3 deps to NOT be installed")
 def test_s3_import_error_missing_deps() -> None:
     use_fs(False)
     with pytest.raises(ImportError):

--- a/pathy/_tests/test_s3.py
+++ b/pathy/_tests/test_s3.py
@@ -16,7 +16,7 @@ def test_s3_scandir_list_buckets(
     from pathy.s3 import ScanDirS3
 
     root = Pathy("s3://foo/bar")
-    client = root._accessor.client(root)  # type:ignore
+    client = root.client(root)
     scandir = ScanDirS3(client=client, path=Pathy())
     buckets = [s.name for s in scandir]
     assert bucket in buckets
@@ -33,7 +33,7 @@ def test_s3_scandir_scandir_continuation_token(
     root = Pathy(f"{with_adapter}://{bucket}/{ENV_ID}/s3_scandir_pagination/")
     for i in range(8):
         (root / f"file{i}.blob").touch()
-    client = root._accessor.client(root)  # type:ignore
+    client = root.client(root)
     scandir = ScanDirS3(client=client, path=root, prefix=root.prefix, page_size=4)
     blobs = [s.name for s in scandir]
     assert len(blobs) == 8
@@ -45,7 +45,7 @@ def test_s3_scandir_invalid_bucket_name(with_adapter: str) -> None:
     from pathy.s3 import ScanDirS3
 
     root = Pathy(f"{with_adapter}://invalid_h3gE_ds5daEf_Sdf15487t2n4/bar")
-    client = root._accessor.client(root)  # type:ignore
+    client = root.client(root)
     scandir = ScanDirS3(client=client, path=root)
     assert len(list(scandir)) == 0
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 pytest>=7.0.0
-mypy==0.981
+mypy==0.942
 isort>=5.10.0
 autoflake>=1.3.0
 flake8>=4.0.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,6 @@
 pytest>=7.0.0
-mypy==0.942
+mypy==0.942; python_version < '3.10'
+mypy==0.981; python_version >= '3.10'
 isort>=5.10.0
 autoflake>=1.3.0
 flake8>=4.0.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 pytest>=7.0.0
-mypy==0.942
+mypy==0.981
 isort>=5.10.0
 autoflake>=1.3.0
 flake8>=4.0.0


### PR DESCRIPTION
Python 3.11 dropped the use of Accessor classes (🎉), but it broke Pathy. 

This PR refactors away from the Accessor class to using BucketClients directly from the Pathy class. This change calls out the one bit of technical debt that the project has: its dependency on pathlib internals. Pathy relies explicitly on the base pathlib class to do glob matches against scandir results. This isn't great because the project breaks when internals change, but it keeps the library simple by not reimplementing wildcard matching functionality. 

Changes:
 - drop the use of _Accessor class from the internals of pathlib.
 - Detect python < 3.11 and provide the base needed accessor method "scandir"
 - Detect python >= 3.11 and provide the Path._scandir function
 - Move accessor methods to the Pathy class

Future Work
 - Remove the use of pathlib scandir entirely and replace it with an inline glob matching system to provide this functionality.