### PR TITLE
feat(azure): support azure blob container storage

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -31,6 +31,7 @@ jobs:
           GCS_CREDENTIALS: ${{ secrets.GCS_CREDENTIALS }}
           PATHY_S3_ACCESS_ID: ${{ secrets.PATHY_S3_ACCESS_ID }}
           PATHY_S3_ACCESS_SECRET: ${{ secrets.PATHY_S3_ACCESS_SECRET }}
+          PATHY_AZURE_CONNECTION_STRING: ${{ secrets.PATHY_AZURE_CONNECTION_STRING }}
         run: rm -rf ./pathy/ && sh tools/test_package.sh
       - name: Report Code Coverage
         env:

--- a/README.md
+++ b/README.md
@@ -41,11 +41,56 @@ assert not greeting.exists()
 
 The table below details the supported cloud provider APIs.
 
-| Cloud Service        | Support |      Install Extras      |
-| :------------------- | :-----: | :----------------------: |
-| Google Cloud Storage |   ✅    | `pip install pathy[gcs]` |
-| Amazon S3            |   ✅    | `pip install pathy[s3]`  |
-| Azure                |   ❌    |                          |
+| Cloud Service        | Support |       Install Extras       |
+| :------------------- | :-----: | :------------------------: |
+| Google Cloud Storage |   ✅    |  `pip install pathy[gcs]`  |
+| Amazon S3            |   ✅    |  `pip install pathy[s3]`   |
+| Azure                |   ✅    | `pip install pathy[azure]` |
+
+### Google Cloud Storage
+
+Google recommends using a JSON credentials file, which you can specify by path:
+
+```python
+from google.oauth2 import service_account
+from pathy import set_client_params
+
+credentials = service_account.Credentials.from_service_account_file("./my-creds.json")
+set_client_params("gs", credentials=credentials)
+```
+
+### Amazon S3
+
+S3 uses a JSON credentials file, which you can specify by path:
+
+```python
+from pathy import set_client_params
+
+set_client_params("s3", key_id="YOUR_ACCESS_KEY_ID", key_secret="YOUR_ACCESS_SECRET")
+```
+
+### Azure
+
+Azure blob storage can be passed a `connection_string`:
+
+```python
+from azure.storage.blob import BlobServiceClient
+from pathy import set_client_params
+
+set_client_params("azure", connection_string="YOUR_CONNECTION_STRING")
+```
+
+or a `BlobServiceClient` instance:
+
+```python
+from azure.storage.blob import BlobServiceClient
+from pathy import set_client_params
+
+service: BlobServiceClient = BlobServiceClient.from_connection_string(
+    "YOUR_CONNECTION_STRING"
+)
+set_client_params("azure", service=service)
+```
 
 ## Semantic Versioning
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,6 @@ set_client_params("s3", key_id="YOUR_ACCESS_KEY_ID", key_secret="YOUR_ACCESS_SEC
 Azure blob storage can be passed a `connection_string`:
 
 ```python
-from azure.storage.blob import BlobServiceClient
 from pathy import set_client_params
 
 set_client_params("azure", connection_string="YOUR_CONNECTION_STRING")

--- a/pathy/__init__.py
+++ b/pathy/__init__.py
@@ -1064,10 +1064,6 @@ class ScanDirFS(PathyScanDir):
     _client: BucketClientFS
 
     def scandir(self) -> Generator[BucketEntry, None, None]:
-        if self._path is None or not self._path.root:
-            return
-        assert self._path is not None
-        assert self._path.root is not None
         scan_path = self._client.root / self._path.root
         if isinstance(self._path, BasePath):
             scan_path = (

--- a/pathy/__init__.py
+++ b/pathy/__init__.py
@@ -206,7 +206,7 @@ class BucketClient:
 
     def scandir(
         self,
-        path: Optional["Pathy"] = None,
+        path: "Pathy",
         prefix: Optional[str] = None,
         delimiter: Optional[str] = None,
     ) -> "PathyScanDir":
@@ -816,7 +816,7 @@ class PathyScanDir(Iterator[Any], ContextManager[Any], ABC):
     def __init__(
         self,
         client: BucketClient,
-        path: Optional[PurePathy] = None,
+        path: PurePathy,
         prefix: Optional[str] = None,
         delimiter: Optional[str] = None,
     ) -> None:
@@ -1008,7 +1008,7 @@ class BucketClientFS(BucketClient):
 
     def scandir(
         self,
-        path: Optional[Pathy] = None,
+        path: Pathy,
         prefix: Optional[str] = None,
         delimiter: Optional[str] = None,
     ) -> PathyScanDir:

--- a/pathy/__init__.py
+++ b/pathy/__init__.py
@@ -196,9 +196,6 @@ class BucketClient:
     def get_bucket(self, path: "Pathy") -> Bucket:
         raise NotImplementedError(SUBCLASS_ERROR)
 
-    def list_buckets(self) -> Generator[Bucket, None, None]:
-        raise NotImplementedError(SUBCLASS_ERROR)
-
     def list_blobs(
         self,
         path: "Pathy",
@@ -1009,11 +1006,6 @@ class BucketClientFS(BucketClient):
             return BucketFS(str(path.root), bucket=bucket_path)
         raise FileNotFoundError(f"Bucket {path.root} does not exist!")
 
-    def list_buckets(self, **kwargs: Dict[str, Any]) -> Generator[BucketFS, None, None]:
-        for f in self.root.glob("*"):
-            if f.is_dir():
-                yield BucketFS(f.name, f)
-
     def scandir(
         self,
         path: Optional[Pathy] = None,
@@ -1073,8 +1065,6 @@ class ScanDirFS(PathyScanDir):
 
     def scandir(self) -> Generator[BucketEntry, None, None]:
         if self._path is None or not self._path.root:
-            for bucket in self._client.list_buckets():
-                yield BucketEntryFS(bucket.name, is_dir=True, raw=None)
             return
         assert self._path is not None
         assert self._path.root is not None

--- a/pathy/_tests/__init__.py
+++ b/pathy/_tests/__init__.py
@@ -23,3 +23,17 @@ try:
 except ImportError:
     s3_installed = False
     s3_testable = False
+
+
+azure_testable: bool
+azure_installed: bool
+
+
+try:
+    from ..azure import BucketClientAzure
+
+    azure_installed = bool(BucketClientAzure)
+    azure_testable = azure_installed and "PATHY_AZURE_CONNECTION_STRING" in os.environ
+except ImportError:
+    azure_installed = False
+    azure_testable = False

--- a/pathy/_tests/test_azure.py
+++ b/pathy/_tests/test_azure.py
@@ -1,15 +1,93 @@
+from dataclasses import dataclass
+
+import mock
 import pytest
 
+from pathy import Pathy
+
 from . import azure_testable
+from .conftest import ENV_ID
 
 AZURE_ADAPTER = ["azure"]
 
 
 @pytest.mark.parametrize("adapter", AZURE_ADAPTER)
-@pytest.mark.skipif(not azure_testable, reason="requires s3")
+@pytest.mark.skipif(not azure_testable, reason="requires azure")
 def test_azure_recreate_expected_args(with_adapter: str) -> None:
     from pathy.azure import BucketClientAzure
 
     # Must specify either service, or connection_string
     with pytest.raises(ValueError):
         BucketClientAzure()
+
+
+@pytest.mark.parametrize("adapter", AZURE_ADAPTER)
+@pytest.mark.skipif(not azure_testable, reason="requires azure")
+def test_azure_bucket_get_blob_failure_cases(with_adapter: str, bucket: str) -> None:
+    root = Pathy(f"{with_adapter}://{bucket}")
+    client = root.client(root)
+    azure_bucket = client.get_bucket(root)
+    # Returns none if blob contains invalid character
+    assert azure_bucket.get_blob("#$%^@#%$@#$@#$") is None
+
+
+@dataclass
+class MockAzureBlobClientCopyProperties:
+    status: str
+    id: str
+
+
+@dataclass
+class MockAzureBlobClientProperties:
+    copy: MockAzureBlobClientCopyProperties
+
+
+@dataclass
+class MockAzureBlobClient:
+    aborted = False
+
+    def start_copy_from_url(self, url: str) -> None:
+        pass
+
+    def get_blob_properties(self) -> MockAzureBlobClientProperties:
+        return MockAzureBlobClientProperties(
+            MockAzureBlobClientCopyProperties(status="failed", id="test")
+        )
+
+    def abort_copy(self, copy_id: str) -> None:
+        self.aborted = True
+
+
+@dataclass
+class MockAzureBlobServiceClient:
+    mock_client: MockAzureBlobClient
+
+    def get_blob_client(self, container: str, blob_name: str) -> MockAzureBlobClient:
+        return self.mock_client
+
+
+@pytest.mark.parametrize("adapter", AZURE_ADAPTER)
+@pytest.mark.skipif(not azure_testable, reason="requires azure")
+def test_azure_bucket_copy_blob_aborts_copy_on_failure(
+    with_adapter: str, bucket: str
+) -> None:
+    root: Pathy = Pathy(f"{with_adapter}://{bucket}/{ENV_ID}/azure_abort_copy")
+
+    # Create a source blob to copy
+    cool_blob = root / "file.txt"
+    cool_blob.write_text("cool")
+    client = root.client(root)
+
+    # Get the bucket client / source blob
+    azure_bucket = client.get_bucket(root)
+    azure_blob = azure_bucket.get_blob(cool_blob.prefix[:-1])
+    assert azure_blob is not None
+
+    # Mock out blob client to catch `abort_copy` call
+    mock_blob_client = MockAzureBlobClient()
+    mock_bucket = MockAzureBlobServiceClient(mock_blob_client)
+    assert mock_blob_client.aborted is False
+    with mock.patch.object(azure_bucket, "client", new=mock_bucket):
+        assert azure_bucket.copy_blob(azure_blob, azure_bucket, "file2.txt") is None
+    # abort_copy was called
+    assert mock_blob_client.aborted is True

--- a/pathy/_tests/test_azure.py
+++ b/pathy/_tests/test_azure.py
@@ -1,0 +1,15 @@
+import pytest
+
+from . import azure_testable
+
+AZURE_ADAPTER = ["azure"]
+
+
+@pytest.mark.parametrize("adapter", AZURE_ADAPTER)
+@pytest.mark.skipif(not azure_testable, reason="requires s3")
+def test_azure_recreate_expected_args(with_adapter: str) -> None:
+    from pathy.azure import BucketClientAzure
+
+    # Must specify either service, or connection_string
+    with pytest.raises(ValueError):
+        BucketClientAzure()

--- a/pathy/_tests/test_base.py
+++ b/pathy/_tests/test_base.py
@@ -172,8 +172,6 @@ def test_client_base_bucket_client_raises_not_implemented() -> None:
     with pytest.raises(NotImplementedError):
         client.get_bucket(Pathy("gs://foo"))
     with pytest.raises(NotImplementedError):
-        client.list_buckets()
-    with pytest.raises(NotImplementedError):
         client.list_blobs(Pathy("gs://foo"))
     with pytest.raises(NotImplementedError):
         client.scandir(Pathy("gs://foo"))

--- a/pathy/_tests/test_file.py
+++ b/pathy/_tests/test_file.py
@@ -4,15 +4,7 @@ from typing import Any, Optional
 import mock
 import pytest
 
-from pathy import (
-    BlobFS,
-    BucketClientFS,
-    BucketFS,
-    ClientError,
-    Pathy,
-    ScanDirFS,
-    get_client,
-)
+from pathy import BlobFS, BucketClientFS, BucketFS, ClientError, Pathy, get_client
 
 FS_ADAPTER = ["fs"]
 
@@ -110,13 +102,3 @@ def test_file_bucket_client_fs_list_blobs(with_adapter: str) -> None:
 
     blobs = [b.name for b in client.list_blobs(root, prefix="foo/bar/baz")]
     assert len(blobs) == 1
-
-
-@pytest.mark.parametrize("adapter", FS_ADAPTER)
-def test_file_scandir_list_buckets(
-    with_adapter: str, bucket: str, other_bucket: str
-) -> None:
-    root = Pathy()
-    client = root.client(root)
-    scandir = ScanDirFS(client=client, path=root)
-    assert sorted([s.name for s in scandir]) == sorted([bucket, other_bucket])

--- a/pathy/_tests/test_gcs.py
+++ b/pathy/_tests/test_gcs.py
@@ -45,19 +45,6 @@ def test_gcs_import_error_missing_deps() -> None:
 
 @pytest.mark.parametrize("adapter", GCS_ADAPTER)
 @pytest.mark.skipif(not gcs_testable, reason="requires gcs")
-def test_gcs_scandir_list_buckets(
-    with_adapter: str, bucket: str, other_bucket: str
-) -> None:
-    from pathy.gcs import ScanDirGCS
-
-    root = Pathy("gs://foo/bar")
-    client = root.client(root)
-    scandir = ScanDirGCS(client=client, path=Pathy())
-    assert sorted([s.name for s in scandir]) == sorted([bucket, other_bucket])
-
-
-@pytest.mark.parametrize("adapter", GCS_ADAPTER)
-@pytest.mark.skipif(not gcs_testable, reason="requires gcs")
 def test_gcs_scandir_invalid_bucket_name(with_adapter: str) -> None:
     from pathy.gcs import ScanDirGCS
 

--- a/pathy/_tests/test_pathy.py
+++ b/pathy/_tests/test_pathy.py
@@ -116,6 +116,7 @@ def test_pathy_exists(with_adapter: str, bucket: str) -> None:
     assert Pathy(f"{with_adapter}://{invalid_bucket}/foo.blob").exists() is False
     # valid bucket with invalid object
     assert Pathy(f"{with_adapter}://{bucket}/not_found_lol_nice.txt").exists() is False
+    assert Pathy(f"{with_adapter}://{bucket}/@^@^#$%@#$.txt").exists() is False
 
     path = Pathy(f"{with_adapter}://{bucket}/{ENV_ID}/directory/foo.txt")
     path.write_text("---")
@@ -154,6 +155,12 @@ def test_pathy_glob(with_adapter: str, bucket: str) -> None:
         root / "0/dir/file.txt",
         root / "1/dir/file.txt",
     ]
+
+    bad_root = Pathy(f"{with_adapter}://{bucket}-bad-name")
+    assert list(bad_root.glob("*.txt")) == []
+
+    bad_name = root / "@#$%@^@%@#@#$.glob"
+    assert list(bad_name.glob("*.glob")) == []
 
 
 @pytest.mark.parametrize("adapter", TEST_ADAPTERS)

--- a/pathy/_tests/test_pathy.py
+++ b/pathy/_tests/test_pathy.py
@@ -25,13 +25,13 @@ from .conftest import ENV_ID, TEST_ADAPTERS
 
 @pytest.mark.parametrize("adapter", TEST_ADAPTERS)
 def test_pathy_is_path_instance(with_adapter: str) -> None:
-    blob = Pathy("gs://fake/blob")
+    blob = Pathy(f"{with_adapter}://fake/blob")
     assert isinstance(blob, Path)
 
 
 @pytest.mark.parametrize("adapter", TEST_ADAPTERS)
 def test_pathy_fluid(with_adapter: str, bucket: str) -> None:
-    path: FluidPath = Pathy.fluid(f"gs://{bucket}/{ENV_ID}/fake-key")
+    path: FluidPath = Pathy.fluid(f"{with_adapter}://{bucket}/{ENV_ID}/fake-key")
     assert isinstance(path, Pathy)
     path = Pathy.fluid("foo/bar.txt")
     assert isinstance(path, BasePath)
@@ -98,10 +98,10 @@ def test_pathy_stat(with_adapter: str, bucket: str) -> None:
 
 @pytest.mark.parametrize("adapter", TEST_ADAPTERS)
 def test_pathy_resolve(with_adapter: str, bucket: str) -> None:
-    path = Pathy(f"gs://{bucket}/{ENV_ID}/fake-key")
+    path = Pathy(f"{with_adapter}://{bucket}/{ENV_ID}/fake-key")
     assert path.resolve() == path
-    path = Pathy(f"gs://{bucket}/{ENV_ID}/dir/../fake-key")
-    assert path.resolve() == Pathy(f"gs://{bucket}/{ENV_ID}/fake-key")
+    path = Pathy(f"{with_adapter}://{bucket}/{ENV_ID}/dir/../fake-key")
+    assert path.resolve() == Pathy(f"{with_adapter}://{bucket}/{ENV_ID}/fake-key")
 
 
 @pytest.mark.parametrize("adapter", TEST_ADAPTERS)
@@ -199,9 +199,9 @@ def test_pathy_iterdir(with_adapter: str, bucket: str) -> None:
         path = root / f"{i}.file"
         path.write_text("---")
 
-    # 1 file in a subfolder
-    path = root / "sub/file.txt"
-    path.write_text("---")
+    # 2 files in a subfolder
+    (root / "sub/file.txt").write_text("---")
+    (root / "sub/file2.txt").write_text("---")
 
     check = sorted(root.iterdir())
     assert check == [

--- a/pathy/_tests/test_s3.py
+++ b/pathy/_tests/test_s3.py
@@ -10,21 +10,6 @@ S3_ADAPTER = ["s3"]
 
 @pytest.mark.parametrize("adapter", S3_ADAPTER)
 @pytest.mark.skipif(not s3_testable, reason="requires s3")
-def test_s3_scandir_list_buckets(
-    with_adapter: str, bucket: str, other_bucket: str
-) -> None:
-    from pathy.s3 import ScanDirS3
-
-    root = Pathy("s3://foo/bar")
-    client = root.client(root)
-    scandir = ScanDirS3(client=client, path=Pathy())
-    buckets = [s.name for s in scandir]
-    assert bucket in buckets
-    assert other_bucket in buckets
-
-
-@pytest.mark.parametrize("adapter", S3_ADAPTER)
-@pytest.mark.skipif(not s3_testable, reason="requires s3")
 def test_s3_scandir_scandir_continuation_token(
     with_adapter: str, bucket: str, other_bucket: str
 ) -> None:

--- a/pathy/azure.py
+++ b/pathy/azure.py
@@ -175,7 +175,7 @@ class BucketClientAzure(BucketClient):
 
     def scandir(  # type:ignore[override]
         self,
-        path: Optional[PurePathy] = None,
+        path: PurePathy,
         prefix: Optional[str] = None,
         delimiter: Optional[str] = None,
     ) -> PathyScanDir:
@@ -216,7 +216,7 @@ class ScanDirAzure(PathyScanDir):
     def __init__(
         self,
         client: BucketClient,
-        path: Optional[PurePathy] = None,
+        path: PurePathy,
         prefix: Optional[str] = None,
         delimiter: Optional[str] = None,
         page_size: Optional[int] = None,
@@ -225,8 +225,6 @@ class ScanDirAzure(PathyScanDir):
         self._page_size = page_size
 
     def scandir(self) -> Generator[BucketEntryAzure, None, None]:
-        if self._path is None:
-            return
         bucket = self._client.lookup_bucket(self._path)
         if bucket is None:
             return

--- a/pathy/azure.py
+++ b/pathy/azure.py
@@ -1,0 +1,253 @@
+from dataclasses import dataclass
+import datetime
+from typing import Any, Dict, Generator, List, Optional, cast
+
+try:
+    import azure
+    from azure.storage.blob import (
+        BlobClient,
+        BlobProperties,
+        BlobServiceClient,
+        ContainerClient,
+    )
+except (ImportError, ModuleNotFoundError):
+    raise ImportError(
+        """You are using the Azure functionality of Pathy without
+    having the required dependencies installed.
+
+    Please try installing them:
+
+        pip install pathy[azure]
+
+    """
+    )
+
+from . import (
+    Blob,
+    Bucket,
+    BucketClient,
+    BucketEntry,
+    PathyScanDir,
+    PurePathy,
+    register_client,
+)
+
+
+def _safe_last_modified(last_modified: Optional[datetime.datetime]) -> int:
+    """Helper to coerce an optional last_modified timestamp into an int"""
+    return int(last_modified.timestamp()) if last_modified else 0
+
+
+class BucketEntryAzure(BucketEntry):
+    bucket: "BucketAzure"
+    raw: Any
+
+
+@dataclass
+class BlobAzure(Blob):
+    client: BlobClient
+    bucket: "BucketAzure"
+
+    def delete(self) -> None:
+        self.client.delete_blob()
+
+    def exists(self) -> bool:
+        return self.client.exists()
+
+
+@dataclass
+class BucketAzure(Bucket):
+    name: str
+    client: BlobServiceClient
+    container: ContainerClient
+
+    def get_blob(self, blob_name: str) -> Optional[BlobAzure]:
+        blob_client = self.client.get_blob_client(container=self.name, blob=blob_name)
+        try:
+            if not blob_client.exists():
+                return None
+        except azure.core.exceptions.HttpResponseError:  # type: ignore
+            # This error is thrown if a blob name has invalid characters in it
+            # TODO: Check a more specific error code?
+            return None
+        blob_stat = blob_client.get_blob_properties()
+        size = blob_stat.size
+        return BlobAzure(
+            client=blob_client,
+            bucket=self,
+            owner=None,  # type:ignore
+            name=blob_name,  # type:ignore
+            raw=None,
+            size=size,
+            updated=_safe_last_modified(blob_stat.last_modified),
+        )
+
+    def copy_blob(  # type:ignore[override]
+        self, blob: BlobAzure, target: "BucketAzure", name: str
+    ) -> Optional[BlobAzure]:
+
+        copied_blob = self.client.get_blob_client(target.container.container_name, name)
+        copied_blob.start_copy_from_url(blob.client.url)
+        props = copied_blob.get_blob_properties()
+        if props.copy.status != "success" and props.copy.id is not None:
+            copied_blob.abort_copy(props.copy.id)
+            return None
+        pathy_blob = BlobAzure(
+            client=copied_blob,
+            bucket=target,
+            owner=None,
+            name=copied_blob.blob_name,
+            raw=None,
+            size=props.size,
+            updated=_safe_last_modified(props.last_modified),
+        )
+        return pathy_blob
+
+    def delete_blob(self, blob: BlobAzure) -> None:  # type:ignore[override]
+        blob.delete()
+
+    def delete_blobs(self, blobs: List[BlobAzure]) -> None:  # type:ignore[override]
+        for blob in blobs:
+            self.delete_blob(blob)
+
+    def exists(self) -> bool:
+        return self.container.exists()
+
+
+class BucketClientAzure(BucketClient):
+    _service: BlobServiceClient
+
+    @property
+    def client_params(self) -> Dict[str, Any]:
+        return dict(client=self._service)
+
+    def __init__(self, **kwargs: Any) -> None:
+        self.recreate(**kwargs)
+
+    def recreate(self, **kwargs: Any) -> None:
+        self._service = kwargs.get("service", None)
+        if self._service is None:
+            connection_string = kwargs.get("connection_string", None)
+            if connection_string is None:
+                raise ValueError("Expected either 'service' or 'connection_string'")
+            self._service = BlobServiceClient.from_connection_string(connection_string)
+
+    def make_uri(self, path: PurePathy) -> str:
+        return str(path)
+
+    def create_bucket(  # type:ignore[override]
+        self, path: PurePathy
+    ) -> ContainerClient:
+        container = self._service.get_container_client(container=path.root)
+        container.create_container()
+        return container
+
+    def delete_bucket(self, path: PurePathy) -> None:
+        container = self._service.get_container_client(container=path.root)
+        container.delete_container()
+
+    def exists(self, path: PurePathy) -> bool:
+        # Because we want all the parents of a valid blob (e.g. "directory" in
+        # "directory/foo.file") to return True, we enumerate the blobs with a prefix
+        # and compare the object names to see if they match a substring of the path
+        key_name = str(path.key)
+        for obj in self.list_blobs(path):
+            if obj.name.startswith(key_name + path._flavour.sep):  # type:ignore
+                return True
+        return False
+
+    def lookup_bucket(self, path: PurePathy) -> Optional[BucketAzure]:
+        try:
+            return self.get_bucket(path)
+        except FileNotFoundError:
+            return None
+
+    def get_bucket(self, path: PurePathy) -> BucketAzure:
+        try:
+            native_bucket = self._service.get_container_client(container=path.root)
+            return BucketAzure(
+                str(path.root), client=self._service, container=native_bucket
+            )
+        except (ValueError):
+            raise FileNotFoundError(f"Bucket {path.root} does not exist!")
+
+    def scandir(  # type:ignore[override]
+        self,
+        path: Optional[PurePathy] = None,
+        prefix: Optional[str] = None,
+        delimiter: Optional[str] = None,
+    ) -> PathyScanDir:
+        return ScanDirAzure(client=self, path=path, prefix=prefix, delimiter=delimiter)
+
+    def list_blobs(
+        self,
+        path: PurePathy,
+        prefix: Optional[str] = None,
+        delimiter: Optional[str] = None,
+    ) -> Generator[BlobAzure, None, None]:
+        bucket = self.lookup_bucket(path)
+        if bucket is None:
+            return
+        paginator = bucket.container.list_blobs(name_starts_with=prefix)
+        props: BlobProperties
+        try:
+            for props in paginator:
+                prop_name = cast(str, props.name)
+                blob_client = bucket.container.get_blob_client(prop_name)
+                yield BlobAzure(
+                    client=blob_client,
+                    bucket=bucket,
+                    owner=None,
+                    name=prop_name,
+                    raw=props,
+                    size=props.size,
+                    updated=_safe_last_modified(props.last_modified),
+                )
+        except azure.core.exceptions.HttpResponseError:  # type: ignore
+            # Response errors can happen when prefix has invalid characters.
+            return
+
+
+class ScanDirAzure(PathyScanDir):
+    _client: BucketClientAzure
+
+    def __init__(
+        self,
+        client: BucketClient,
+        path: Optional[PurePathy] = None,
+        prefix: Optional[str] = None,
+        delimiter: Optional[str] = None,
+        page_size: Optional[int] = None,
+    ) -> None:
+        super().__init__(client=client, path=path, prefix=prefix, delimiter=delimiter)
+        self._page_size = page_size
+
+    def scandir(self) -> Generator[BucketEntryAzure, None, None]:
+        if self._path is None:
+            return
+        bucket = self._client.lookup_bucket(self._path)
+        if bucket is None:
+            return
+        paginator = bucket.container.list_blobs(name_starts_with=self._prefix)
+        blob: BlobProperties
+        seen_dirs: Dict[str, bool] = {}
+        for blob in paginator:
+            is_dir = False
+            blob_name = cast(str, blob.name)
+            if self._prefix:
+                blob_name = blob_name[len(self._prefix) :]
+            if blob_name.find("/") != -1:
+                blob_name = blob_name[0 : blob_name.find("/")]
+                if blob_name in seen_dirs:
+                    continue
+                seen_dirs[blob_name] = True
+                is_dir = True
+            yield BucketEntryAzure(
+                name=blob_name,
+                is_dir=is_dir,
+                size=cast(int, blob.size),
+                last_modified=_safe_last_modified(blob.last_modified),
+            )
+
+
+register_client("azure", BucketClientAzure)

--- a/pathy/gcs.py
+++ b/pathy/gcs.py
@@ -145,7 +145,7 @@ class BucketClientGCS(BucketClient):
 
     def scandir(  # type:ignore[override]
         self,
-        path: Optional[PurePathy] = None,
+        path: PurePathy,
         prefix: Optional[str] = None,
         delimiter: Optional[str] = None,
     ) -> PathyScanDir:
@@ -179,8 +179,6 @@ class ScanDirGCS(PathyScanDir):
     _client: BucketClientGCS
 
     def scandir(self) -> Generator[BucketEntryGCS, None, None]:
-        if self._path is None or not self._path.root:
-            return
         sep = self._path._flavour.sep  # type:ignore
         bucket = self._client.lookup_bucket(self._path)
         if bucket is None:

--- a/pathy/gcs.py
+++ b/pathy/gcs.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Any, Dict, Generator, List, Optional
+from typing import Any, Generator, List, Optional
 
 try:
     from google.api_core.exceptions import BadRequest  # type:ignore
@@ -143,11 +143,6 @@ class BucketClientGCS(BucketClient):
             pass
         raise FileNotFoundError(f"Bucket {path.root} does not exist!")
 
-    def list_buckets(  # type:ignore[override]
-        self, **kwargs: Dict[str, Any]
-    ) -> Generator[GCSNativeBucket, None, None]:
-        return self.client.list_buckets(**kwargs)  # type:ignore
-
     def scandir(  # type:ignore[override]
         self,
         path: Optional[PurePathy] = None,
@@ -185,11 +180,6 @@ class ScanDirGCS(PathyScanDir):
 
     def scandir(self) -> Generator[BucketEntryGCS, None, None]:
         if self._path is None or not self._path.root:
-            gcs_bucket: GCSNativeBucket
-            for gcs_bucket in self._client.list_buckets():
-                yield BucketEntryGCS(
-                    gcs_bucket.name, is_dir=True, raw=None  # type:ignore
-                )
             return
         sep = self._path._flavour.sep  # type:ignore
         bucket = self._client.lookup_bucket(self._path)

--- a/pathy/s3.py
+++ b/pathy/s3.py
@@ -168,13 +168,6 @@ class BucketClientS3(BucketClient):
         except (ClientError, ParamValidationError):
             raise FileNotFoundError(f"Bucket {path.root} does not exist!")
 
-    def list_buckets(  # type:ignore[override]
-        self, **kwargs: Dict[str, Any]
-    ) -> Generator[S3NativeBucket, None, None]:
-        native_buckets = self.client.list_buckets(**kwargs)["Buckets"]
-        results = (BucketS3(n["Name"], self.client, n) for n in native_buckets)
-        return results
-
     def scandir(  # type:ignore[override]
         self,
         path: Optional[PurePathy] = None,
@@ -225,9 +218,6 @@ class ScanDirS3(PathyScanDir):
 
     def scandir(self) -> Generator[BucketEntryS3, None, None]:
         if self._path is None or not self._path.root:
-            s3_bucket: BucketS3
-            for s3_bucket in self._client.list_buckets():
-                yield BucketEntryS3(s3_bucket.name, is_dir=True, raw=None)
             return
         sep = self._path._flavour.sep  # type:ignore
         bucket = self._client.lookup_bucket(self._path)

--- a/pathy/s3.py
+++ b/pathy/s3.py
@@ -170,7 +170,7 @@ class BucketClientS3(BucketClient):
 
     def scandir(  # type:ignore[override]
         self,
-        path: Optional[PurePathy] = None,
+        path: PurePathy,
         prefix: Optional[str] = None,
         delimiter: Optional[str] = None,
     ) -> PathyScanDir:
@@ -208,7 +208,7 @@ class ScanDirS3(PathyScanDir):
     def __init__(
         self,
         client: BucketClient,
-        path: Optional[PurePathy] = None,
+        path: PurePathy,
         prefix: Optional[str] = None,
         delimiter: Optional[str] = None,
         page_size: Optional[int] = None,
@@ -217,8 +217,6 @@ class ScanDirS3(PathyScanDir):
         self._page_size = page_size
 
     def scandir(self) -> Generator[BucketEntryS3, None, None]:
-        if self._path is None or not self._path.root:
-            return
         sep = self._path._flavour.sep  # type:ignore
         bucket = self._client.lookup_bucket(self._path)
         if bucket is None:

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ def setup_package():
     extras = {
         "gcs": ["google-cloud-storage>=1.26.0,<2.0.0"],
         "s3": ["boto3"],
+        "azure": ["azure-storage-blob"],
         "test": ["pytest", "pytest-coverage", "mock", "typer-cli"],
     }
     extras["all"] = [item for group in extras.values() for item in group]


### PR DESCRIPTION
 - add azure implementation, and register with scheme "azure"
 - update test suite to use azure client when "azure" adapter is requested
 - add `pathy[azure]` extras to setup.py
 - remove "list_buckets" from BucketClient classes
 - fixes #81

BREAKING CHANGE: This removes an internal bit of code that allows for enumerating buckets in certain situations. The API was impossible to reach without going indirectly through the glob functionality, and it's unclear whether the code paths were ever reached outside of specific unit testing situations. If there's an explicit need for listing buckets, we can add a top-level API for it.