### PR TITLE
fix(azure): "azure" scheme was not registered

### DIFF
--- a/pathy/__init__.py
+++ b/pathy/__init__.py
@@ -1113,6 +1113,7 @@ _client_registry: Dict[str, Type[BucketClient]] = {
 _optional_clients: Dict[str, str] = {
     "gs": "pathy.gcs",
     "s3": "pathy.s3",
+    "azure": "pathy.azure",
 }
 BucketClientType = TypeVar("BucketClientType", bound=BucketClient)
 


### PR DESCRIPTION
The 0.8.0 release includes azure support, but it was not registered as an optional client to load.