### PR TITLE
Fix Absolute Paths (Windows/Unix)

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -47,15 +47,15 @@ jobs:
         with:
           python-version: 3.11
       - name: Install dependencies
-        run: sh .\tools\setup.bat
+        run: .\tools\setup.bat
       - name: Build Wheel
-        run: sh .\tools\build.bat
+        run: .\tools\build.bat
       - name: Test Wheel (local only)
         run: rmdir /S /Q "pathy" 2>nul && .\tools\test_package.bat
       - name: Report Code Coverage
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-        run: sh .\tools\codecov.bat
+        run: .\tools\codecov.bat
 
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -51,7 +51,9 @@ jobs:
       - name: Build Wheel
         run: .\tools\build.bat
       - name: Test Wheel (local only)
-        run: rmdir /S /Q "pathy" 2>nul && .\tools\test_package.bat
+        run: |
+          rmdir /S ".\pathy" 2>nul
+          .\tools\test_package.bat
       - name: Report Code Coverage
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -38,6 +38,25 @@ jobs:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         run: sh tools/codecov.sh
 
+  build-windows:
+    runs-on: 'windows-latest'
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.11
+      - name: Install dependencies
+        run: sh .\tools\setup.bat
+      - name: Build Wheel
+        run: sh .\tools\build.bat
+      - name: Test Wheel (local only)
+        run: rmdir /S /Q "pathy" 2>nul && .\tools\test_package.bat
+      - name: Report Code Coverage
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        run: sh .\tools\codecov.bat
+
   deploy:
     runs-on: ubuntu-latest
     needs: "build"

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -50,10 +50,12 @@ jobs:
         run: .\tools\setup.bat
       - name: Build Wheel
         run: .\tools\build.bat
+      - name: Remove Pathy folder
+        uses: JesseTG/rm@v1.0.3
+        with:
+          path: .\pathy
       - name: Test Wheel (local only)
-        run: |
-          rmdir /S ".\pathy" 2>nul
-          .\tools\test_package.bat
+        run: .\tools\test_package.bat
       - name: Report Code Coverage
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/pathy/__init__.py
+++ b/pathy/__init__.py
@@ -91,7 +91,7 @@ class BucketEntry:
         name: str,
         is_dir: bool = False,
         size: int = -1,
-        last_modified: int = -1,
+        last_modified: Optional[int] = None,
         raw: Optional[Blob] = None,
     ):
         self.name = name
@@ -626,8 +626,6 @@ class Pathy(Path, PurePathy):
         self_type = type(self)
         result = target if isinstance(target, self_type) else self_type(target)
         result._absolute_path_validation()  # type:ignore
-        # super().rename(result)
-        # return result
 
         client: BucketClient = self.client(self)
         bucket: Bucket = client.get_bucket(self)

--- a/pathy/__init__.py
+++ b/pathy/__init__.py
@@ -881,8 +881,9 @@ class BucketFS(Bucket):
         # https://docs.python.org/3/library/pathlib.html#pathlib.Path.owner
         owner: Optional[str]
         try:
-            owner = native_blob.owner()
-        except KeyError:
+            # path.owner() raises NotImplementedError on windows
+            owner = native_blob.owner()  # type:ignore
+        except (KeyError, NotImplementedError):
             owner = None
         return BlobFS(
             bucket=self,

--- a/pathy/__init__.py
+++ b/pathy/__init__.py
@@ -281,9 +281,6 @@ class PurePathy(PurePath):
         ```python
         assert Pathy("gs://foo/bar").scheme == "gs"
         assert Pathy("file:///tmp/foo/bar").scheme == "file"
-        assert Pathy("/dev/null").scheme == ""
-        assert Pathy("C:\\pathy\\subfolder").scheme == ""
-
         """
         # If there is no drive, return nothing
         if self.drive == "":
@@ -372,7 +369,7 @@ class Pathy(Path, PurePathy):
     _accessor: BucketsAccessor = BucketsAccessor()
     _NOT_SUPPORTED_MESSAGE = "{method} is an unsupported bucket operation"
     _UNSUPPORTED_PATH = (
-        "ERROR: absolute file paths must be initialized using Pathy.fluid(path)"
+        "absolute file paths must be initialized using Pathy.fluid(path)"
     )
     _client: Optional[BucketClient]
 

--- a/pathy/_tests/test_base.py
+++ b/pathy/_tests/test_base.py
@@ -39,65 +39,65 @@ def test_base_home() -> None:
 
 
 def test_base_expanduser() -> None:
-    path = Pathy("/fake-bucket/fake-key")
+    path = Pathy("gs://fake-bucket/fake-key")
     with pytest.raises(NotImplementedError):
         path.expanduser()
 
 
 def test_base_chmod() -> None:
-    path = Pathy("/fake-bucket/fake-key")
+    path = Pathy("gs://fake-bucket/fake-key")
     with pytest.raises(NotImplementedError):
         path.chmod(0o666)
 
 
 def test_base_lchmod() -> None:
-    path = Pathy("/fake-bucket/fake-key")
+    path = Pathy("gs://fake-bucket/fake-key")
     with pytest.raises(NotImplementedError):
         path.lchmod(0o666)
 
 
 def test_base_group() -> None:
-    path = Pathy("/fake-bucket/fake-key")
+    path = Pathy("gs://fake-bucket/fake-key")
     with pytest.raises(NotImplementedError):
         path.group()
 
 
 def test_base_is_mount() -> None:
-    assert not Pathy("/fake-bucket/fake-key").is_mount()
+    assert not Pathy("gs://fake-bucket/fake-key").is_mount()
 
 
 def test_base_is_symlink() -> None:
-    assert not Pathy("/fake-bucket/fake-key").is_symlink()
+    assert not Pathy("gs://fake-bucket/fake-key").is_symlink()
 
 
 def test_base_is_socket() -> None:
-    assert not Pathy("/fake-bucket/fake-key").is_socket()
+    assert not Pathy("gs://fake-bucket/fake-key").is_socket()
 
 
 def test_base_is_fifo() -> None:
-    assert not Pathy("/fake-bucket/fake-key").is_fifo()
+    assert not Pathy("gs://fake-bucket/fake-key").is_fifo()
 
 
 def test_base_is_block_device() -> None:
-    path = Pathy("/fake-bucket/fake-key")
+    path = Pathy("gs://fake-bucket/fake-key")
     with pytest.raises(NotImplementedError):
         path.is_block_device()
 
 
 def test_base_is_char_device() -> None:
-    path = Pathy("/fake-bucket/fake-key")
+    path = Pathy("gs://fake-bucket/fake-key")
     with pytest.raises(NotImplementedError):
         path.is_char_device()
 
 
 def test_base_lstat() -> None:
-    path = Pathy("/fake-bucket/fake-key")
+    path = Pathy("gs://fake-bucket/fake-key")
     with pytest.raises(NotImplementedError):
         path.lstat()
 
 
 def test_base_symlink_to() -> None:
-    path = Pathy("/fake-bucket/fake-key")
+    path = Pathy("gs://fake-bucket/fake-key")
     with pytest.raises(NotImplementedError):
         path.symlink_to("file_name")
 

--- a/pathy/_tests/test_base.py
+++ b/pathy/_tests/test_base.py
@@ -212,5 +212,5 @@ def test_bucket_entry_defaults() -> None:
     assert "size" in repr(entry)
     stat = entry.stat()
     assert isinstance(stat, BlobStat)
-    assert stat.last_modified == -1
+    assert stat.last_modified is None
     assert stat.size == -1

--- a/pathy/_tests/test_cli.py
+++ b/pathy/_tests/test_cli.py
@@ -272,11 +272,11 @@ def test_cli_ls_diff_years_modified() -> None:
     root.mkdir(parents=True, exist_ok=True)
 
     # Create one file right now
-    new_path = root / f"new_file.txt"
+    new_path = root / "new_file.txt"
     new_path.write_text("new")
 
     # Create another and set its modified time to one year before now
-    old_path = root / f"old_file.txt"
+    old_path = root / "old_file.txt"
     old_path.write_text("old")
     old_stat = old_path.stat()
     assert isinstance(old_stat, os.stat_result), "expect local file"

--- a/pathy/_tests/test_file.py
+++ b/pathy/_tests/test_file.py
@@ -42,7 +42,8 @@ def test_file_bucket_client_fs_make_uri(with_adapter: str) -> None:
     client: BucketClientFS = get_client("gs")
     blob = Pathy("gs://foo/bar")
     actual = client.make_uri(blob)
-    expected = f"file://{client.root}/foo/bar"
+    sep = client.root._flavour.sep  # type:ignore
+    expected = f"file://{client.root}{sep}foo{sep}bar"
     assert actual == expected
 
     # Invalid root

--- a/pathy/_tests/test_file.py
+++ b/pathy/_tests/test_file.py
@@ -32,7 +32,7 @@ def test_file_bucket_client_fs_open(with_adapter: str) -> None:
     blob = Pathy("gs://foo/bar")
     with pytest.raises(ClientError):
         client.open(blob)
-    blob.mkdir()
+    blob.parent.mkdir(parents=True, exist_ok=True)
     blob.touch()
     assert client.open(blob) is not None
 

--- a/pathy/_tests/test_pathy.py
+++ b/pathy/_tests/test_pathy.py
@@ -37,6 +37,8 @@ def test_pathy_fluid(with_adapter: str, bucket: str) -> None:
     assert isinstance(path, BasePath)
     path = Pathy.fluid("/dev/null")
     assert isinstance(path, BasePath)
+    path = Pathy.fluid("C:\\Windows\\Path")
+    assert isinstance(path, BasePath)
 
 
 @pytest.mark.parametrize("adapter", TEST_ADAPTERS)

--- a/pathy/_tests/test_pathy.py
+++ b/pathy/_tests/test_pathy.py
@@ -29,6 +29,14 @@ def test_pathy_is_path_instance(with_adapter: str) -> None:
     assert isinstance(blob, Path)
 
 
+def test_pathy_error_invalid_scheme_paths() -> None:
+    # Initializing a path with an absolute system path warns
+    with pytest.raises(ValueError):
+        Pathy("c:\\temp\\other\\file.txt")
+    with pytest.raises(ValueError):
+        Pathy("/tmp/other/file.txt")
+
+
 @pytest.mark.parametrize("adapter", TEST_ADAPTERS)
 def test_pathy_fluid(with_adapter: str, bucket: str) -> None:
     path: FluidPath = Pathy.fluid(f"{with_adapter}://{bucket}/{ENV_ID}/fake-key")

--- a/pathy/_tests/test_pure_pathy.py
+++ b/pathy/_tests/test_pure_pathy.py
@@ -28,6 +28,7 @@ def test_pure_pathy_scheme_extraction() -> None:
     assert PurePathy("s3://var/tests/fake").scheme == "s3"
     assert PurePathy("file://var/tests/fake").scheme == "file"
     assert PurePathy("/var/tests/fake").scheme == ""
+    assert PurePathy("C:\\pathy\\subfolder").scheme == ""
 
 
 @pytest.mark.skipif(sys.version_info < (3, 6), reason="requires python3.6 or higher")

--- a/pathy/_tests/test_windows.py
+++ b/pathy/_tests/test_windows.py
@@ -32,3 +32,28 @@ def test_windows_fluid_absolute_paths() -> None:
     assert new_folder.exists() is True
 
     shutil.rmtree(tmp_dir)
+
+
+@pytest.mark.skipif(not is_windows, reason="requires windows")
+def test_windows_fluid_absolute_file_paths() -> None:
+    # Path with \\ slashes
+    tmp_dir = tempfile.mkdtemp()
+    # Converted to the same path with / slashes
+    alt_slashes = tmp_dir.replace("\\\\", "/").replace("\\", "/")
+
+    # Make a folder from \\ absolute path
+    fs_root = Pathy.fluid(f"file://{tmp_dir}")
+    assert "\\" in str(fs_root), "expected \\ separators in windows path"
+    new_folder = Pathy.fluid(fs_root / "sub-dir")
+    assert new_folder.exists() is False
+    new_folder.mkdir()
+    assert new_folder.exists() is True
+
+    # Make a folder from / absolute path
+    fs_root = Pathy.fluid(f"file://{alt_slashes}")
+    new_folder = Pathy.fluid(fs_root / "sub-dir-alt/")
+    assert new_folder.exists() is False
+    new_folder.mkdir()
+    assert new_folder.exists() is True
+
+    shutil.rmtree(tmp_dir)

--- a/pathy/_tests/test_windows.py
+++ b/pathy/_tests/test_windows.py
@@ -1,9 +1,10 @@
 import os
 import shutil
 import tempfile
+
 import pytest
+
 from pathy import Pathy
-from .conftest import ENV_ID, TEST_ADAPTERS
 
 is_windows = os.name == "nt"
 

--- a/pathy/_tests/test_windows.py
+++ b/pathy/_tests/test_windows.py
@@ -1,0 +1,33 @@
+import os
+import shutil
+import tempfile
+import pytest
+from pathy import Pathy
+from .conftest import ENV_ID, TEST_ADAPTERS
+
+is_windows = os.name == "nt"
+
+
+@pytest.mark.skipif(not is_windows, reason="requires windows")
+def test_windows_fluid_absolute_paths() -> None:
+    # Path with \\ slashes
+    tmp_dir = tempfile.mkdtemp()
+    # Converted to the same path with / slashes
+    alt_slashes = tmp_dir.replace("\\\\", "/").replace("\\", "/")
+
+    # Make a folder from \\ absolute path
+    fs_root = Pathy.fluid(tmp_dir)
+    assert "\\" in str(fs_root), "expected \\ separators in windows path"
+    new_folder = Pathy.fluid(fs_root / "sub-dir")
+    assert new_folder.exists() is False
+    new_folder.mkdir()
+    assert new_folder.exists() is True
+
+    # Make a folder from / absolute path
+    fs_root = Pathy.fluid(alt_slashes)
+    new_folder = Pathy.fluid(fs_root / "sub-dir-alt")
+    assert new_folder.exists() is False
+    new_folder.mkdir()
+    assert new_folder.exists() is True
+
+    shutil.rmtree(tmp_dir)

--- a/tools/build.bat
+++ b/tools/build.bat
@@ -1,0 +1,13 @@
+echo "This is designed to run in Windows PowerShell."
+
+if not exist ".winenv" (
+    echo "Making virtual environment (.winenv)"
+    pip install virtualenv --upgrade
+    python -m virtualenv .winenv -p python3
+)
+
+echo "Cleaning output folders"
+call .\tools\clean.bat
+
+echo "Build python package..."
+.\.winenv\Scripts\python setup.py sdist bdist_wheel

--- a/tools/clean.bat
+++ b/tools/clean.bat
@@ -1,0 +1,7 @@
+echo "Removing build files..."
+
+rmdir /S /Q "dist" 2>nul
+rmdir /S /Q "build" 2>nul
+rmdir /S /Q "htmlcov" 2>nul
+rmdir /S /Q ".test-env" 2>nul
+rmdir /S /Q "pathy.egg-info" 2>nul

--- a/tools/codecov.bat
+++ b/tools/codecov.bat
@@ -1,0 +1,2 @@
+.\.winenv\Scripts\pip install codecov
+.\.winenv\Scripts\python -m codecov

--- a/tools/format.bat
+++ b/tools/format.bat
@@ -1,0 +1,15 @@
+echo "This is designed to run in Windows PowerShell."
+
+if not exist ".winenv" (
+    echo "Making virtual environment (.winenv)"
+    pip install virtualenv --upgrade
+    python -m virtualenv .winenv -p python3
+)
+
+echo "Installing/updating dev requirements..."
+.\.winenv\Scripts\pip install -r requirements.txt -r requirements-local.txt
+echo "Sort imports one per line, so autoflake can remove unused imports"
+.\.winenv\Scripts\python -m isort pathy --force-single-line-imports
+.\.winenv\Scripts\python -m autoflake --remove-all-unused-imports --recursive --remove-unused-variables --in-place main.py --exclude=__init__.py
+.\.winenv\Scripts\python -m isort pathy
+.\.winenv\Scripts\python -m black pathy

--- a/tools/format.sh
+++ b/tools/format.sh
@@ -1,6 +1,5 @@
 #!/bin/sh -e
 . .env/bin/activate
-
 # Sort imports one per line, so autoflake can remove unused imports
 isort pathy --force-single-line-imports
 autoflake --remove-all-unused-imports --recursive --remove-unused-variables --in-place pathy --exclude=__init__.py

--- a/tools/lint.bat
+++ b/tools/lint.bat
@@ -1,0 +1,20 @@
+echo "This is designed to run in Windows PowerShell."
+
+if not exist ".winenv" (
+    echo "Making virtual environment (.winenv)"
+    pip install virtualenv --upgrade
+    python -m virtualenv .winenv -p python3
+)
+
+echo "Installing/updating dev requirements..."
+.\.winenv\Scripts\pip install -r requirements.txt -r requirements-dev.txt
+
+echo "========================= mypy"
+.\.winenv\Scripts\python.exe -m mypy pathy
+echo "========================= flake8"
+.\.winenv\Scripts\python.exe -m flake8 pathy
+echo "========================= black"
+.\.winenv\Scripts\python.exe -m black pathy --check
+echo "========================= pyright"
+npx pyright --version
+npx pyright pathy

--- a/tools/lint.sh
+++ b/tools/lint.sh
@@ -1,12 +1,10 @@
 #!/usr/bin/env bash
-
 set -e
 . .env/bin/activate
-
 echo "========================= mypy"
 mypy pathy --strict-equality --disallow-untyped-calls --disallow-untyped-defs
 echo "========================= flake8"
-flake8 pathy
+flake8 "pathy"
 echo "========================= black"
 black pathy --check
 echo "========================= pyright"

--- a/tools/setup.bat
+++ b/tools/setup.bat
@@ -1,0 +1,11 @@
+echo "This is designed to run in Windows PowerShell."
+
+if not exist ".winenv" (
+    echo "Making virtual environment (.winenv)"
+    pip install virtualenv --upgrade
+    python -m virtualenv .winenv -p python3
+)
+
+echo "Installing/updating requirements..."
+.\.winenv\Scripts\pip install -r requirements.txt -r requirements-dev.txt
+.\.winenv\Scripts\pip install -e ".[all]"

--- a/tools/test.bat
+++ b/tools/test.bat
@@ -1,0 +1,4 @@
+echo "This is designed to run in Windows PowerShell."
+
+echo "Run tests..."
+.\.winenv\Scripts\python -m pytest pathy/_tests --cov=pathy

--- a/tools/test_package.bat
+++ b/tools/test_package.bat
@@ -1,0 +1,10 @@
+echo "This is designed to run in Windows PowerShell."
+
+pushd ".\dist"
+for %%a in ("*.whl") do set WHEEL=".\dist\%%a"
+popd
+
+.\.winenv\Scripts\pip install pip install "%WHEEL%[test]"
+
+echo " === Running tests WITHOUT package extras installed..."
+.\.winenv\Scripts\python -m pytest --pyargs pathy._tests --cov=pathy


### PR DESCRIPTION
 - throw an error if Pathy is initialized with an absolute system path (suggest using Pathy.fluid in message)
 - fix issue where windows paths weren't resolved to bucket slashes properly
 - add windows test runner to CI build
 - fixes #87 
 - fixes #69