### PR TITLE
fix(stat): return BlobStat for all pathy paths

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-20.04]
         python-version: [3.6, 3.7, 3.8, 3.9, 3.10.6, 3.11]
 
     runs-on: ${{ matrix.os }}
@@ -39,7 +39,7 @@ jobs:
         run: sh tools/codecov.sh
 
   build-windows:
-    runs-on: 'windows-latest'
+    runs-on: "windows-latest"
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python

--- a/pathy/_tests/test_base.py
+++ b/pathy/_tests/test_base.py
@@ -124,6 +124,15 @@ def test_base_path_check_mode() -> None:
 
     assert root._check_mode(value_error_fn) is False
 
+    # Raises from OSError with unknown code
+    def other_os_error_fn(mode: int) -> bool:
+        err = OSError()
+        err.errno = 1337
+        raise err
+
+    with pytest.raises(OSError):
+        root._check_mode(other_os_error_fn)
+
     # Raises other unrelated exceptions
     def other_error_fn(mode: int) -> bool:
         raise BaseException()

--- a/pathy/_tests/test_cli.py
+++ b/pathy/_tests/test_cli.py
@@ -5,7 +5,7 @@ import tempfile
 import pytest
 from typer.testing import CliRunner
 
-from pathy import Pathy
+from pathy import BlobStat, Pathy
 from pathy.cli import app
 
 from .conftest import ENV_ID, TEST_ADAPTERS
@@ -279,14 +279,17 @@ def test_cli_ls_diff_years_modified() -> None:
     old_path = root / "old_file.txt"
     old_path.write_text("old")
     old_stat = old_path.stat()
-    assert isinstance(old_stat, os.stat_result), "expect local file"
+    assert isinstance(old_stat, BlobStat)
     one_year = 31556926  # seconds
+    assert old_stat.last_modified is not None
     os.utime(
-        str(old_path), (old_stat.st_atime - one_year, old_stat.st_mtime - one_year)
+        str(old_path),
+        (old_stat.last_modified - one_year, old_stat.last_modified - one_year),
     )
     new_old_stat = old_path.stat()
-    assert isinstance(new_old_stat, os.stat_result), "expect local file"
-    assert int(old_stat.st_mtime) == int(new_old_stat.st_mtime + one_year)
+    assert new_old_stat.last_modified is not None
+    assert isinstance(new_old_stat, BlobStat)
+    assert int(old_stat.last_modified) == int(new_old_stat.last_modified + one_year)
 
     result = runner.invoke(app, ["ls", "-l", str(root)])
     assert result.exit_code == 0


### PR DESCRIPTION
Return `BlobStat` consistently for local and remote paths.

Changes
- implement `stat` in `BasePath` and yield `BlobStat`s instead of `os.stat_result`.
- implement all the pathlib file mode checking helpers because they use `self.stat()` internally which doesn't work with BlobStats.
- add tests for base path helpers
- update CLI test to assert that stats are BlobStat now

BREAKING CHANGE: Previously, when using Pathy.fluid paths that point to local file system paths, Pathy would return an `os.stat_result` rather than a `BlobStat`. This made it difficult to treat mixed paths consistently.

Now Pathy returns a BlobStat structure for local and remote paths.

If you need to use `os.stat_result`, you can still call `os.stat(my_path)` to access it.