### PR TITLE
feat(cli): make typer an optional dependency via pathy[cli]

### DIFF
--- a/pathy/_tests/__init__.py
+++ b/pathy/_tests/__init__.py
@@ -24,3 +24,12 @@ try:
 except ImportError as e:
     print(f"Azure dependencies: {e}.")
     azure_installed = False
+
+cli_installed: bool
+try:
+    from ..cli import app  # noqa: F401
+
+    cli_installed = True
+except ImportError as e:
+    print(f"CLI dependencies: {e}.")
+    cli_installed = False

--- a/pathy/_tests/test_cli.py
+++ b/pathy/_tests/test_cli.py
@@ -2,19 +2,38 @@ import pathlib
 import tempfile
 
 import pytest
-from typer.testing import CliRunner
 
 from pathy import BlobStat, BucketClientFS, Pathy
-from pathy.cli import app
 
+from . import cli_installed
 from .conftest import ENV_ID, TEST_ADAPTERS
 
-runner = CliRunner()
+if cli_installed:
+    from typer.testing import CliRunner
+
+    from pathy.cli import app
+
+    runner = CliRunner()
+
+requires_cli = pytest.mark.skipif(not cli_installed, reason="requires pathy[cli]")
+
+
+@pytest.mark.skipif(cli_installed, reason="requires cli deps to NOT be installed")
+def test_cli_import_error_missing_deps() -> None:
+    import importlib
+    import sys
+
+    # Remove cached module so re-import triggers the ImportError guard
+    sys.modules.pop("pathy.cli", None)
+    with pytest.raises(ImportError):
+        importlib.import_module("pathy.cli")
+
 
 # TODO: add support for wildcard cp/mv/rm/ls paths (e.g. "pathy cp gs://my/*.file ./")
 # TODO: add support for streaming in/out sources (e.g. "pathy cp - gs://my/my.file")
 
 
+@requires_cli
 @pytest.mark.parametrize("adapter", TEST_ADAPTERS)
 def test_cli_cp_invalid_from_path(with_adapter: str, bucket: str) -> None:
     source = f"{with_adapter}://{bucket}/{ENV_ID}/cli_cp_file_invalid/file.txt"
@@ -23,6 +42,7 @@ def test_cli_cp_invalid_from_path(with_adapter: str, bucket: str) -> None:
     assert not Pathy(destination).is_file()
 
 
+@requires_cli
 @pytest.mark.parametrize("adapter", TEST_ADAPTERS)
 def test_cli_cp_file(with_adapter: str, bucket: str) -> None:
     source = f"{with_adapter}://{bucket}/{ENV_ID}/cli_cp_file/file.txt"
@@ -33,6 +53,7 @@ def test_cli_cp_file(with_adapter: str, bucket: str) -> None:
     assert Pathy(destination).is_file()
 
 
+@requires_cli
 @pytest.mark.parametrize("adapter", TEST_ADAPTERS)
 def test_cli_cp_file_name_from_source(with_adapter: str, bucket: str) -> None:
     source = pathlib.Path("./file.txt")
@@ -43,6 +64,7 @@ def test_cli_cp_file_name_from_source(with_adapter: str, bucket: str) -> None:
     source.unlink()
 
 
+@requires_cli
 @pytest.mark.parametrize("adapter", TEST_ADAPTERS)
 def test_cli_cp_folder(with_adapter: str, bucket: str) -> None:
     root = Pathy(f"{with_adapter}://{bucket}/{ENV_ID}/")
@@ -59,6 +81,7 @@ def test_cli_cp_folder(with_adapter: str, bucket: str) -> None:
             assert (destination / f"{i}" / f"{j}").is_file()
 
 
+@requires_cli
 @pytest.mark.parametrize("adapter", TEST_ADAPTERS)
 def test_cli_mv_folder(with_adapter: str, bucket: str) -> None:
     root = Pathy(f"{with_adapter}://{bucket}/{ENV_ID}/")
@@ -80,6 +103,7 @@ def test_cli_mv_folder(with_adapter: str, bucket: str) -> None:
             assert (destination / f"{i}" / f"{j}").is_file()
 
 
+@requires_cli
 @pytest.mark.parametrize("adapter", TEST_ADAPTERS)
 def test_cli_mv_file_copy_from_name(with_adapter: str, bucket: str) -> None:
     source = pathlib.Path("./file.txt")
@@ -91,6 +115,7 @@ def test_cli_mv_file_copy_from_name(with_adapter: str, bucket: str) -> None:
     assert not source.exists()
 
 
+@requires_cli
 @pytest.mark.parametrize("adapter", TEST_ADAPTERS)
 def test_cli_mv_file(with_adapter: str, bucket: str) -> None:
     source = f"{with_adapter}://{bucket}/{ENV_ID}/cli_mv_file/file.txt"
@@ -102,6 +127,7 @@ def test_cli_mv_file(with_adapter: str, bucket: str) -> None:
     assert Pathy(destination).is_file()
 
 
+@requires_cli
 @pytest.mark.parametrize("adapter", TEST_ADAPTERS)
 def test_cli_mv_file_across_buckets(
     with_adapter: str, bucket: str, other_bucket: str
@@ -117,6 +143,7 @@ def test_cli_mv_file_across_buckets(
     assert Pathy(destination).is_file()
 
 
+@requires_cli
 @pytest.mark.parametrize("adapter", TEST_ADAPTERS)
 def test_cli_mv_folder_across_buckets(
     with_adapter: str, bucket: str, other_bucket: str
@@ -141,6 +168,7 @@ def test_cli_mv_folder_across_buckets(
             assert (destination / f"{i}" / f"{j}").is_file()
 
 
+@requires_cli
 @pytest.mark.parametrize("adapter", TEST_ADAPTERS)
 def test_cli_rm_invalid_file(with_adapter: str, bucket: str) -> None:
     source = f"{with_adapter}://{bucket}/{ENV_ID}/cli_rm_file_invalid/file.txt"
@@ -149,6 +177,7 @@ def test_cli_rm_invalid_file(with_adapter: str, bucket: str) -> None:
     assert runner.invoke(app, ["rm", source]).exit_code == 1
 
 
+@requires_cli
 @pytest.mark.parametrize("adapter", TEST_ADAPTERS)
 def test_cli_rm_file(with_adapter: str, bucket: str) -> None:
     source = f"{with_adapter}://{bucket}/{ENV_ID}/cli_rm_file/file.txt"
@@ -159,6 +188,7 @@ def test_cli_rm_file(with_adapter: str, bucket: str) -> None:
     assert not path.exists()
 
 
+@requires_cli
 @pytest.mark.parametrize("adapter", TEST_ADAPTERS)
 def test_cli_rm_verbose(with_adapter: str, bucket: str) -> None:
     root = Pathy(f"{with_adapter}://{bucket}/{ENV_ID}/") / "cli_rm_folder"
@@ -178,6 +208,7 @@ def test_cli_rm_verbose(with_adapter: str, bucket: str) -> None:
     assert other in result.output
 
 
+@requires_cli
 @pytest.mark.parametrize("adapter", TEST_ADAPTERS)
 def test_cli_rm_folder(with_adapter: str, bucket: str) -> None:
     root = Pathy(f"{with_adapter}://{bucket}/{ENV_ID}/")
@@ -196,6 +227,7 @@ def test_cli_rm_folder(with_adapter: str, bucket: str) -> None:
             assert not (source / f"{i}" / f"{j}").is_file()
 
 
+@requires_cli
 @pytest.mark.parametrize("adapter", TEST_ADAPTERS)
 def test_cli_ls_invalid_source(with_adapter: str, bucket: str) -> None:
     root = Pathy(f"{with_adapter}://{bucket}/{ENV_ID}/") / "cli_ls_invalid"
@@ -206,6 +238,7 @@ def test_cli_ls_invalid_source(with_adapter: str, bucket: str) -> None:
     assert "No such file or directory" in result.output
 
 
+@requires_cli
 @pytest.mark.parametrize("adapter", TEST_ADAPTERS)
 def test_cli_ls(with_adapter: str, bucket: str) -> None:
     root = Pathy(f"{with_adapter}://{bucket}/{ENV_ID}/") / "cli_ls"
@@ -229,6 +262,7 @@ def test_cli_ls(with_adapter: str, bucket: str) -> None:
     assert str(root / "folder") in result.output
 
 
+@requires_cli
 @pytest.mark.parametrize("adapter", TEST_ADAPTERS)
 def test_cli_ls_local_files(with_adapter: str, bucket: str) -> None:
     root = Pathy.fluid(tempfile.mkdtemp()) / ENV_ID / "ls"
@@ -264,6 +298,7 @@ def test_cli_ls_local_files(with_adapter: str, bucket: str) -> None:
     assert str(root / "folder") in result.output
 
 
+@requires_cli
 @pytest.mark.parametrize("adapter", ["fs"])
 def test_cli_ls_diff_years_modified(with_adapter: str, bucket: str) -> None:
     import os

--- a/pathy/cli.py
+++ b/pathy/cli.py
@@ -2,7 +2,17 @@ from datetime import datetime
 from pathlib import Path
 from typing import List, Union
 
-import typer
+try:
+    import typer
+except (ImportError, ModuleNotFoundError):
+    raise ImportError("""You are using the CLI functionality of Pathy without
+    having the required dependencies installed.
+
+    Please try installing them:
+
+        pip install pathy[cli]
+
+    """)
 
 from . import BasePath, FluidPath, Pathy
 from .about import __version__

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,14 +21,15 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
 ]
-dependencies = ["smart-open>=5.2.1", "typer>=0.3.0", "pathlib_abc>=0.5.2,<0.6"]
+dependencies = ["smart-open>=5.2.1", "pathlib_abc>=0.5.2,<0.6"]
 
 [project.optional-dependencies]
+cli = ["typer>=0.3.0"]
 gcs = ["google-cloud-storage>=2.0.0"]
 s3 = ["boto3"]
 azure = ["azure-storage-blob"]
 test = ["pytest", "pytest-cov"]
-all = ["pathy[gcs]", "pathy[s3]", "pathy[azure]", "pathy[test]"]
+all = ["pathy[cli]", "pathy[gcs]", "pathy[s3]", "pathy[azure]", "pathy[test]"]
 
 [project.scripts]
 pathy = "pathy.cli:app"

--- a/uv.lock
+++ b/uv.lock
@@ -1220,7 +1220,6 @@ source = { editable = "." }
 dependencies = [
     { name = "pathlib-abc" },
     { name = "smart-open" },
-    { name = "typer" },
 ]
 
 [package.optional-dependencies]
@@ -1230,9 +1229,13 @@ all = [
     { name = "google-cloud-storage" },
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "typer" },
 ]
 azure = [
     { name = "azure-storage-blob" },
+]
+cli = [
+    { name = "typer" },
 ]
 gcs = [
     { name = "google-cloud-storage" },
@@ -1272,9 +1275,10 @@ requires-dist = [
     { name = "pytest-cov", marker = "extra == 'all'" },
     { name = "pytest-cov", marker = "extra == 'test'" },
     { name = "smart-open", specifier = ">=5.2.1" },
-    { name = "typer", specifier = ">=0.3.0" },
+    { name = "typer", marker = "extra == 'all'", specifier = ">=0.3.0" },
+    { name = "typer", marker = "extra == 'cli'", specifier = ">=0.3.0" },
 ]
-provides-extras = ["all", "azure", "gcs", "s3", "test"]
+provides-extras = ["all", "azure", "cli", "gcs", "s3", "test"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION

- closes #99

BREAKING CHANGE: The `pathy` CLI app is only available when installing all extras, or the `pathy[cli]` extra specifically. A helpful error is shown to aid in resolving any issues that arise from this change.